### PR TITLE
Fix Jade stale response race

### DIFF
--- a/web-v2/Dockerfile
+++ b/web-v2/Dockerfile
@@ -3,7 +3,7 @@
 FROM rust:1.93-bookworm AS lwk-builder
 
 ARG LWK_REF=jade-serial-improvements
-ARG LWK_COMMIT=b2d0ad3ccbca3839b968e4ec48f5e64fae5db328
+ARG LWK_COMMIT=31fdeca963816a3c83e431b2240802183d78a9ec
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git pkg-config libssl-dev ca-certificates clang \


### PR DESCRIPTION
Fix Jade "stale response" errors after quick page reload ([31fdeca963816a3c83e431b2240802183d78a9ec](https://github.com/lilbonekit/lwk/pull/3/changes/31fdeca963816a3c83e431b2240802183d78a9ec))

When you reload the page right after navigating around on the Jade device's own screen (e.g. opening "Scan QR" and going back), the app could throw weird errors like:

- `invalid type: boolean true, expected struct VersionInfoResult`
- `data did not match any variant of untagged enum IsAuthResult`

**Why**: Jade pauses answering pending requests while showing its own menus. If you reload mid-pause, the old delayed answer can arrive right when the new page is waiting for a different request's answer, and the old library blindly treated whatever came back first as the answer — even if it didn't match.

**Fix**: bumps the pinned LWK commit (LWK_COMMIT in this Dockerfile) to a version of lwk_jade that checks each response's id before trusting it, and discards leftover/stale ones instead of crashing on them.