### PR TITLE
Feat/new indexer endpoints

### DIFF
--- a/.sqlx/query-1baaa15bde4d110d88bc760b26b6f5a4576db6853f426af4a549f945ac914ce6.json
+++ b/.sqlx/query-1baaa15bde4d110d88bc760b26b6f5a4576db6853f426af4a549f945ac914ce6.json
@@ -18,7 +18,8 @@
                 "cancellation",
                 "repayment",
                 "liquidation",
-                "claim"
+                "claim",
+                "borrower_principal"
               ]
             }
           }

--- a/.sqlx/query-55466b4753b467252554afaaed68a9b1ca89a46532fa6087f59cc1704f7c8f50.json
+++ b/.sqlx/query-55466b4753b467252554afaaed68a9b1ca89a46532fa6087f59cc1704f7c8f50.json
@@ -31,7 +31,8 @@
                 "cancellation",
                 "repayment",
                 "liquidation",
-                "claim"
+                "claim",
+                "borrower_principal"
               ]
             }
           }

--- a/.sqlx/query-71f942711d77042e8e74c1aa28c44896a4dacbacfc49e78a6e457d52b2043c02.json
+++ b/.sqlx/query-71f942711d77042e8e74c1aa28c44896a4dacbacfc49e78a6e457d52b2043c02.json
@@ -31,7 +31,8 @@
                 "cancellation",
                 "repayment",
                 "liquidation",
-                "claim"
+                "claim",
+                "borrower_principal"
               ]
             }
           }

--- a/crates/indexer/README.md
+++ b/crates/indexer/README.md
@@ -221,7 +221,7 @@ The following parameters are available for `GET /offers` and for the `offers` li
 **Offer details** (`GET /offers/{id}`) — full offer fields (short + NFT asset ids) plus:
 
 - `participants`: latest participant UTXO per role (`borrower`, `lender`)
-- `utxos`: current unspent offer UTXOs only (`spent_txid IS NULL`)
+- `utxos`: current unspent offer UTXOs only (`spent_txid IS NULL`). Active offers may include both `active_offer` (Lending covenant) and `borrower_principal` (borrower principal AssetAuth locked until repayment).
 
 **Borrower dashboard** (`GET /borrowers/by-script`):
 

--- a/crates/indexer/README.md
+++ b/crates/indexer/README.md
@@ -185,7 +185,7 @@ cargo build -p lending-indexer --no-default-features
 
 ### Filtering Parameters (Query Params)
 
-The following parameters are available for `GET /offers` and `GET /borrowers/offers`:
+The following parameters are available for `GET /offers`, `GET /borrowers/offers`, and `GET /lenders/offers`:
 
 - `status`: Filter by one or more offer states (`pending`, `active`, `repaid`, `liquidated`, `cancelled`, `claimed`). Use a comma-separated list, e.g. `status=pending,active`.
 - `factory_id`: Filter by issuance factory UUID.
@@ -198,7 +198,7 @@ The following parameters are available for `GET /offers` and `GET /borrowers/off
 
 ### Response Shapes
 
-**Short offer** (`OfferListItemShort`) — used in `GET /offers` and `GET /borrowers/offers`:
+**Short offer** (`OfferListItemShort`) — used in `GET /offers`, `GET /borrowers/offers`, and `GET /lenders/offers`:
 
 - `id`, `issuance_factory_id`, `status`
 - `collateral_asset`, `principal_asset` (hex)
@@ -207,7 +207,7 @@ The following parameters are available for `GET /offers` and `GET /borrowers/off
 - `loan_expiration_height` (block height)
 - `created_at_height`, `created_at_txid` (hex)
 
-**Paginated offer list** (`GET /offers`, `GET /borrowers/offers`):
+**Paginated offer list** (`GET /offers`, `GET /borrowers/offers`, `GET /lenders/offers`):
 
 ```json
 {
@@ -234,7 +234,20 @@ The following parameters are available for `GET /offers` and `GET /borrowers/off
 }
 ```
 
-Overview sums (`collateral_locked`, `borrowings`) are per asset across the borrower's open offers (`pending` and `active`); each `amount` is a decimal satoshi string. Counts (`active_loans`, `pending_offers`) are totals by status.
+Overview sums (`collateral_locked`, `borrowings`) are per asset across the borrower's open offers (`pending` and `active`); each `amount` is a decimal satoshi string. Counts (`active_loans`, `pending_offers`) are totals by status. Overview is not affected by offer-list filters on `GET /borrowers/offers`.
+
+**Lender overview** (`GET /lenders/overview`):
+
+```json
+{
+  "supplied_loans": [{ "asset": "…", "amount": "500" }],
+  "interest_outstanding": [{ "asset": "…", "amount": "6" }],
+  "active_loans": 1,
+  "to_be_claimed": 1
+}
+```
+
+`supplied_loans` and `interest_outstanding` aggregate **active** offers only, grouped by principal asset. Interest uses the full fee formula `principal_amount * interest_rate / 10000` (basis points). `to_be_claimed` counts offers in `repaid` status. Overview is not affected by offer-list filters on `GET /lenders/offers`.
 
 ### Borrowers Endpoints
 
@@ -242,6 +255,13 @@ Overview sums (`collateral_locked`, `borrowings`) are per asset across the borro
 | :--- | :--- | :--- | :--- |
 | `GET` | `/borrowers/overview` | Borrower overview totals | `script_pubkey` (query param, hex) |
 | `GET` | `/borrowers/offers` | Paginated short offer list for the borrower | `script_pubkey` (query param, hex); offer list filters (see above) |
+
+### Lenders Endpoints
+
+| Method | Endpoint | Description | Params / Body |
+| :--- | :--- | :--- | :--- |
+| `GET` | `/lenders/overview` | Lender overview totals | `script_pubkey` (query param, hex) |
+| `GET` | `/lenders/offers` | Paginated short offer list for the lender | `script_pubkey` (query param, hex); offer list filters (see above) |
 
 ### Factories Endpoints
 

--- a/crates/indexer/README.md
+++ b/crates/indexer/README.md
@@ -206,6 +206,8 @@ The following parameters are available for `GET /offers`, `GET /borrowers/offers
 - `interest_rate` (basis points, e.g. 1000 = 10%)
 - `loan_expiration_height` (block height)
 - `created_at_height`, `created_at_txid` (hex)
+- `participants`: latest participant per role (`borrower`, `lender`) — script pubkey only
+- `borrower_principal_utxo`: unspent `borrower_principal` UTXO outpoint (`txid`, `vout`), or omitted when none
 
 **Paginated offer list** (`GET /offers`, `GET /borrowers/offers`, `GET /lenders/offers`):
 

--- a/crates/indexer/README.md
+++ b/crates/indexer/README.md
@@ -185,7 +185,7 @@ cargo build -p lending-indexer --no-default-features
 
 ### Filtering Parameters (Query Params)
 
-The following parameters are available for `GET /offers` and for the `offers` list inside `GET /borrowers/by-script`:
+The following parameters are available for `GET /offers` and `GET /borrowers/offers`:
 
 - `status`: Filter by one or more offer states (`pending`, `active`, `repaid`, `liquidated`, `cancelled`, `claimed`). Use a comma-separated list, e.g. `status=pending,active`.
 - `factory_id`: Filter by issuance factory UUID.
@@ -198,7 +198,7 @@ The following parameters are available for `GET /offers` and for the `offers` li
 
 ### Response Shapes
 
-**Short offer** (`OfferListItemShort`) — used in `GET /offers` and `GET /borrowers/by-script` → `offers.items`:
+**Short offer** (`OfferListItemShort`) — used in `GET /offers` and `GET /borrowers/offers`:
 
 - `id`, `issuance_factory_id`, `status`
 - `collateral_asset`, `principal_asset` (hex)
@@ -207,7 +207,7 @@ The following parameters are available for `GET /offers` and for the `offers` li
 - `loan_expiration_height` (block height)
 - `created_at_height`, `created_at_txid` (hex)
 
-**Paginated offer list** (`GET /offers`, `GET /borrowers/by-script` → `offers`):
+**Paginated offer list** (`GET /offers`, `GET /borrowers/offers`):
 
 ```json
 {
@@ -223,27 +223,25 @@ The following parameters are available for `GET /offers` and for the `offers` li
 - `participants`: latest participant UTXO per role (`borrower`, `lender`)
 - `utxos`: current unspent offer UTXOs only (`spent_txid IS NULL`). Active offers may include both `active_offer` (Lending covenant) and `borrower_principal` (borrower principal AssetAuth locked until repayment).
 
-**Borrower dashboard** (`GET /borrowers/by-script`):
+**Borrower overview** (`GET /borrowers/overview`):
 
 ```json
 {
-  "overview": {
-    "collateral_locked": [{ "asset": "…", "amount": "1000" }],
-    "borrowings": [{ "asset": "…", "amount": "500" }],
-    "active_loans": 1,
-    "pending_offers": 2
-  },
-  "offers": { "items": [], "total": 0, "limit": 50, "offset": 0 }
+  "collateral_locked": [{ "asset": "…", "amount": "1000" }],
+  "borrowings": [{ "asset": "…", "amount": "500" }],
+  "active_loans": 1,
+  "pending_offers": 2
 }
 ```
 
-Overview sums (`collateral_locked`, `borrowings`) are per asset across the borrower's open offers (`pending` and `active`); each `amount` is a decimal satoshi string. Counts (`active_loans`, `pending_offers`) are totals by status. The offer list is scoped to offers where the given `script_pubkey` is the latest borrower.
+Overview sums (`collateral_locked`, `borrowings`) are per asset across the borrower's open offers (`pending` and `active`); each `amount` is a decimal satoshi string. Counts (`active_loans`, `pending_offers`) are totals by status.
 
 ### Borrowers Endpoints
 
 | Method | Endpoint | Description | Params / Body |
 | :--- | :--- | :--- | :--- |
-| `GET` | `/borrowers/by-script` | Borrower dashboard: overview totals and paginated short offer list | `script_pubkey` (query param, hex); offer list filters (see above) |
+| `GET` | `/borrowers/overview` | Borrower overview totals | `script_pubkey` (query param, hex) |
+| `GET` | `/borrowers/offers` | Paginated short offer list for the borrower | `script_pubkey` (query param, hex); offer list filters (see above) |
 
 ### Factories Endpoints
 

--- a/crates/indexer/README.md
+++ b/crates/indexer/README.md
@@ -225,6 +225,18 @@ The following parameters are available for `GET /offers`, `GET /borrowers/offers
 - `participants`: latest participant UTXO per role (`borrower`, `lender`)
 - `utxos`: current unspent offer UTXOs only (`spent_txid IS NULL`). Active offers may include both `active_offer` (Lending covenant) and `borrower_principal` (borrower principal AssetAuth locked until repayment).
 
+**Offers overview** (`GET /offers/overview`):
+
+```json
+{
+  "collateral_locked": [{ "asset": "…", "amount": "1000" }],
+  "active_loan_principal": [{ "asset": "…", "amount": "500" }],
+  "active_loans_count": 1
+}
+```
+
+Aggregates **active** offers for `active_loan_principal` and `active_loans_count`. `collateral_locked` includes **pending** and **active** offers. Amounts are grouped by asset; each `amount` is a decimal satoshi string.
+
 **Borrower overview** (`GET /borrowers/overview`):
 
 ```json
@@ -276,6 +288,7 @@ Overview sums (`collateral_locked`, `borrowings`) are per asset across the borro
 
 | Method | Endpoint | Description | Params / Body |
 | :--- | :--- | :--- | :--- |
+| `GET` | `/offers/overview` | Protocol-wide active loan totals | — |
 | `GET` | `/offers` | Paginated short offer list | offer list filters (see above) |
 | `GET` | `/offers/by-script` | Offer IDs where `script_pubkey` matches an unspent participant UTXO (borrower or lender) | `script_pubkey` (query param, hex) |
 | `GET` | `/offers/{id}` | Full offer details with latest participant UTXOs and unspent offer UTXOs | — |

--- a/crates/indexer/migrations/20260618120000_add_borrower_principal_utxo_type.sql
+++ b/crates/indexer/migrations/20260618120000_add_borrower_principal_utxo_type.sql
@@ -1,0 +1,1 @@
+ALTER TYPE utxo_type ADD VALUE IF NOT EXISTS 'borrower_principal';

--- a/crates/indexer/src/api/borrowers/db.rs
+++ b/crates/indexer/src/api/borrowers/db.rs
@@ -1,7 +1,9 @@
 use sqlx::{PgPool, Postgres, QueryBuilder};
 
 use crate::api::OfferListQuery;
-use crate::api::offers::db::{apply_offer_list_filters, push_offer_list_order_by};
+use crate::api::offers::db::{
+    apply_offer_list_filters, enrich_offer_list_items, push_offer_list_order_by,
+};
 use crate::api::offers::dto::{OfferListItemShort, OfferListResponse};
 use crate::api::participants::push_latest_participant_offers_scope;
 use crate::api::utils::{format_hex, format_satoshis};
@@ -172,7 +174,9 @@ pub async fn fetch_offer_list(
         .fetch_all(db)
         .await?;
 
-    let items = rows.into_iter().map(OfferListItemShort::from).collect();
+    let mut items: Vec<OfferListItemShort> =
+        rows.into_iter().map(OfferListItemShort::from).collect();
+    enrich_offer_list_items(db, &mut items).await?;
 
     Ok(OfferListResponse {
         items,

--- a/crates/indexer/src/api/borrowers/db.rs
+++ b/crates/indexer/src/api/borrowers/db.rs
@@ -6,7 +6,7 @@ use crate::api::offers::dto::{OfferListItemShort, OfferListResponse};
 use crate::api::utils::{format_hex, format_satoshis};
 use crate::models::{OfferModelShort, OfferStatus, ParticipantType};
 
-use super::dto::{AssetAmount, BorrowerDashboardResponse, BorrowerOverview};
+use super::dto::{AssetAmount, BorrowerOverview};
 
 const OPEN_BORROWER_STATUSES: [OfferStatus; 2] = [OfferStatus::Pending, OfferStatus::Active];
 
@@ -56,7 +56,7 @@ fn asset_amounts_from_rows(rows: Vec<AssetSumRow>) -> Vec<AssetAmount> {
     skip(db, script_pubkey),
     fields(script_pubkey = %hex::encode(script_pubkey))
 )]
-async fn fetch_overview(
+pub async fn fetch_overview(
     db: &PgPool,
     script_pubkey: &[u8],
 ) -> Result<BorrowerOverview, sqlx::Error> {
@@ -126,7 +126,7 @@ async fn fetch_overview(
     })
 }
 
-async fn fetch_offer_list(
+pub async fn fetch_offer_list(
     db: &PgPool,
     script_pubkey: &[u8],
     query: &OfferListQuery,
@@ -179,30 +179,4 @@ async fn fetch_offer_list(
         limit,
         offset,
     })
-}
-
-#[tracing::instrument(
-    name = "Fetching borrower dashboard from DB",
-    skip(db, script_pubkey, query),
-    fields(
-        script_pubkey = %hex::encode(script_pubkey),
-        limit = %query.effective_limit(),
-        offset = %query.effective_offset(),
-        status = ?query.status,
-        collateral_asset = ?query.collateral_asset,
-        principal_asset = ?query.principal_asset,
-        factory_id = ?query.factory_id,
-        sort_by = ?query.sort_by,
-        sort_dir = ?query.sort_dir,
-    )
-)]
-pub async fn fetch_dashboard(
-    db: &PgPool,
-    script_pubkey: &[u8],
-    query: OfferListQuery,
-) -> Result<BorrowerDashboardResponse, sqlx::Error> {
-    let overview = fetch_overview(db, script_pubkey).await?;
-    let offers = fetch_offer_list(db, script_pubkey, &query).await?;
-
-    Ok(BorrowerDashboardResponse { overview, offers })
 }

--- a/crates/indexer/src/api/borrowers/dto.rs
+++ b/crates/indexer/src/api/borrowers/dto.rs
@@ -1,8 +1,6 @@
 use serde::Serialize;
 use utoipa::ToSchema;
 
-use crate::api::offers::dto::OfferListResponse;
-
 #[derive(Serialize, ToSchema)]
 pub struct AssetAmount {
     pub asset: String,
@@ -17,10 +15,4 @@ pub struct BorrowerOverview {
     pub borrowings: Vec<AssetAmount>,
     pub active_loans: u64,
     pub pending_offers: u64,
-}
-
-#[derive(Serialize, ToSchema)]
-pub struct BorrowerDashboardResponse {
-    pub overview: BorrowerOverview,
-    pub offers: OfferListResponse,
 }

--- a/crates/indexer/src/api/borrowers/handlers.rs
+++ b/crates/indexer/src/api/borrowers/handlers.rs
@@ -5,32 +5,56 @@ use axum::{
     extract::{Query, State},
 };
 
-use crate::api::openapi::{BorrowerDashboardParams, ErrorResponse};
+use crate::api::offers::dto::OfferListResponse;
+use crate::api::openapi::{BorrowerOffersParams, BorrowerOverviewParams, ErrorResponse};
 use crate::api::utils::parse_script_pubkey;
 use crate::api::{ApiError, AppState};
 
-use super::dto::BorrowerDashboardResponse;
-use super::params::BorrowerDashboardQuery;
+use super::dto::BorrowerOverview;
+use super::params::{BorrowerOffersQuery, BorrowerOverviewQuery};
 
 #[utoipa::path(
     get,
-    path = "/borrowers/by-script",
+    path = "/borrowers/overview",
     tag = "borrowers",
-    params(BorrowerDashboardParams),
+    params(BorrowerOverviewParams),
     responses(
-        (status = 200, description = "Borrower overview and paginated offer list", body = BorrowerDashboardResponse),
+        (status = 200, description = "Borrower overview totals", body = BorrowerOverview),
         (status = 400, description = "Invalid script_pubkey hex", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse),
     )
 )]
-#[tracing::instrument(name = "Getting borrower dashboard by script", skip(state, query))]
-pub async fn get_by_script(
+#[tracing::instrument(name = "Getting borrower overview by script", skip(state, query))]
+pub async fn get_overview_by_script(
     State(state): State<Arc<AppState>>,
-    Query(query): Query<BorrowerDashboardQuery>,
-) -> Result<Json<BorrowerDashboardResponse>, ApiError> {
+    Query(query): Query<BorrowerOverviewQuery>,
+) -> Result<Json<BorrowerOverview>, ApiError> {
     let script_bytes = parse_script_pubkey(&query.script_pubkey)?;
 
-    let dashboard = super::db::fetch_dashboard(&state.db, &script_bytes, query.filters).await?;
+    let overview = super::db::fetch_overview(&state.db, &script_bytes).await?;
 
-    Ok(Json(dashboard))
+    Ok(Json(overview))
+}
+
+#[utoipa::path(
+    get,
+    path = "/borrowers/offers",
+    tag = "borrowers",
+    params(BorrowerOffersParams),
+    responses(
+        (status = 200, description = "Paginated short offer list for the borrower", body = OfferListResponse),
+        (status = 400, description = "Invalid query parameters", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse),
+    )
+)]
+#[tracing::instrument(name = "Getting borrower offers by script", skip(state, query))]
+pub async fn list_offers_by_script(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<BorrowerOffersQuery>,
+) -> Result<Json<OfferListResponse>, ApiError> {
+    let script_bytes = parse_script_pubkey(&query.script_pubkey)?;
+
+    let offers = super::db::fetch_offer_list(&state.db, &script_bytes, &query.filters).await?;
+
+    Ok(Json(offers))
 }

--- a/crates/indexer/src/api/borrowers/handlers.rs
+++ b/crates/indexer/src/api/borrowers/handlers.rs
@@ -17,6 +17,7 @@ use super::params::{BorrowerOffersQuery, BorrowerOverviewQuery};
     get,
     path = "/borrowers/overview",
     tag = "borrowers",
+    operation_id = "get_borrower_overview_by_script",
     params(BorrowerOverviewParams),
     responses(
         (status = 200, description = "Borrower overview totals", body = BorrowerOverview),
@@ -40,6 +41,7 @@ pub async fn get_overview_by_script(
     get,
     path = "/borrowers/offers",
     tag = "borrowers",
+    operation_id = "list_borrower_offers_by_script",
     params(BorrowerOffersParams),
     responses(
         (status = 200, description = "Paginated short offer list for the borrower", body = OfferListResponse),

--- a/crates/indexer/src/api/borrowers/params.rs
+++ b/crates/indexer/src/api/borrowers/params.rs
@@ -1,10 +1,14 @@
 use serde::Deserialize;
 
 use crate::api::params::OfferFilters;
+use crate::api::params::ScriptQuery;
 
-/// Borrower dashboard query: wallet script plus offer-list filters (flat query string).
+/// Query parameters for `GET /borrowers/overview`.
+pub type BorrowerOverviewQuery = ScriptQuery;
+
+/// Query parameters for `GET /borrowers/offers`: wallet script plus offer-list filters.
 #[derive(Deserialize, Debug)]
-pub struct BorrowerDashboardQuery {
+pub struct BorrowerOffersQuery {
     pub script_pubkey: String,
     #[serde(flatten)]
     pub filters: OfferFilters,
@@ -12,14 +16,14 @@ pub struct BorrowerDashboardQuery {
 
 #[cfg(test)]
 mod tests {
-    use super::BorrowerDashboardQuery;
+    use super::BorrowerOffersQuery;
 
     #[test]
-    fn borrower_dashboard_query_parses_flat_pagination() {
-        let parsed: BorrowerDashboardQuery = serde_urlencoded::from_str(
+    fn borrower_offers_query_parses_flat_pagination() {
+        let parsed: BorrowerOffersQuery = serde_urlencoded::from_str(
             "script_pubkey=0014d0c4a3ef09e887b6e99e397e518fe3e41a118ca1&limit=10",
         )
-        .expect("parse borrower dashboard query");
+        .expect("parse borrower offers query");
 
         assert_eq!(
             parsed.script_pubkey,

--- a/crates/indexer/src/api/borrowers/routes.rs
+++ b/crates/indexer/src/api/borrowers/routes.rs
@@ -7,5 +7,7 @@ use crate::api::AppState;
 use super::handlers;
 
 pub fn routes() -> Router<Arc<AppState>> {
-    Router::new().route("/borrowers/by-script", get(handlers::get_by_script))
+    Router::new()
+        .route("/borrowers/overview", get(handlers::get_overview_by_script))
+        .route("/borrowers/offers", get(handlers::list_offers_by_script))
 }

--- a/crates/indexer/src/api/lenders/db.rs
+++ b/crates/indexer/src/api/lenders/db.rs
@@ -1,15 +1,15 @@
 use sqlx::{PgPool, Postgres, QueryBuilder};
 
 use crate::api::OfferListQuery;
+use crate::api::borrowers::dto::AssetAmount;
 use crate::api::offers::db::{apply_offer_list_filters, push_offer_list_order_by};
 use crate::api::offers::dto::{OfferListItemShort, OfferListResponse};
 use crate::api::participants::push_latest_participant_offers_scope;
 use crate::api::utils::{format_hex, format_satoshis};
+
 use crate::models::{OfferModelShort, OfferStatus, ParticipantType};
 
-use super::dto::{AssetAmount, BorrowerOverview};
-
-const OPEN_BORROWER_STATUSES: [OfferStatus; 2] = [OfferStatus::Pending, OfferStatus::Active];
+use super::dto::LenderOverview;
 
 #[derive(sqlx::FromRow)]
 struct AssetSumRow {
@@ -18,9 +18,9 @@ struct AssetSumRow {
 }
 
 #[derive(sqlx::FromRow)]
-struct BorrowerCountsRow {
+struct LenderCountsRow {
     active_loans: i64,
-    pending_offers: i64,
+    to_be_claimed: i64,
 }
 
 fn asset_amounts_from_rows(rows: Vec<AssetSumRow>) -> Vec<AssetAmount> {
@@ -33,52 +33,52 @@ fn asset_amounts_from_rows(rows: Vec<AssetSumRow>) -> Vec<AssetAmount> {
 }
 
 #[tracing::instrument(
-    name = "Fetching borrower overview from DB",
+    name = "Fetching lender overview from DB",
     skip(db, script_pubkey),
     fields(script_pubkey = %hex::encode(script_pubkey))
 )]
 pub async fn fetch_overview(
     db: &PgPool,
     script_pubkey: &[u8],
-) -> Result<BorrowerOverview, sqlx::Error> {
-    let mut collateral_builder: QueryBuilder<Postgres> = QueryBuilder::new(
+) -> Result<LenderOverview, sqlx::Error> {
+    let mut supplied_builder: QueryBuilder<Postgres> = QueryBuilder::new(
         r#"
-        SELECT collateral_asset_id AS asset_id, SUM(collateral_amount)::BIGINT AS amount
+        SELECT principal_asset_id AS asset_id, SUM(principal_amount)::BIGINT AS amount
         FROM offers
-        WHERE 1=1
-        "#,
+        WHERE current_status = "#,
     );
+    supplied_builder.push_bind(OfferStatus::Active);
+    supplied_builder.push(" AND 1=1");
     push_latest_participant_offers_scope(
-        &mut collateral_builder,
-        ParticipantType::Borrower,
+        &mut supplied_builder,
+        ParticipantType::Lender,
         script_pubkey,
     );
-    collateral_builder.push(" AND current_status = ANY(");
-    collateral_builder.push_bind(OPEN_BORROWER_STATUSES);
-    collateral_builder.push(") GROUP BY collateral_asset_id");
+    supplied_builder.push(" GROUP BY principal_asset_id");
 
-    let collateral_rows = collateral_builder
+    let supplied_rows = supplied_builder
         .build_query_as::<AssetSumRow>()
         .fetch_all(db)
         .await?;
 
-    let mut borrowings_builder: QueryBuilder<Postgres> = QueryBuilder::new(
+    let mut interest_builder: QueryBuilder<Postgres> = QueryBuilder::new(
         r#"
-        SELECT principal_asset_id AS asset_id, SUM(principal_amount)::BIGINT AS amount
+        SELECT
+            principal_asset_id AS asset_id,
+            SUM((principal_amount * interest_rate / 10000))::BIGINT AS amount
         FROM offers
-        WHERE 1=1
-        "#,
+        WHERE current_status = "#,
     );
+    interest_builder.push_bind(OfferStatus::Active);
+    interest_builder.push(" AND 1=1");
     push_latest_participant_offers_scope(
-        &mut borrowings_builder,
-        ParticipantType::Borrower,
+        &mut interest_builder,
+        ParticipantType::Lender,
         script_pubkey,
     );
-    borrowings_builder.push(" AND current_status = ANY(");
-    borrowings_builder.push_bind(OPEN_BORROWER_STATUSES);
-    borrowings_builder.push(") GROUP BY principal_asset_id");
+    interest_builder.push(" GROUP BY principal_asset_id");
 
-    let borrowings_rows = borrowings_builder
+    let interest_rows = interest_builder
         .build_query_as::<AssetSumRow>()
         .fetch_all(db)
         .await?;
@@ -93,29 +93,29 @@ pub async fn fetch_overview(
         r#")::BIGINT AS active_loans,
             COUNT(*) FILTER (WHERE current_status = "#,
     );
-    counts_builder.push_bind(OfferStatus::Pending);
+    counts_builder.push_bind(OfferStatus::Repaid);
     counts_builder.push(
-        r#")::BIGINT AS pending_offers
+        r#")::BIGINT AS to_be_claimed
         FROM offers
         WHERE 1=1
         "#,
     );
     push_latest_participant_offers_scope(
         &mut counts_builder,
-        ParticipantType::Borrower,
+        ParticipantType::Lender,
         script_pubkey,
     );
 
     let counts = counts_builder
-        .build_query_as::<BorrowerCountsRow>()
+        .build_query_as::<LenderCountsRow>()
         .fetch_one(db)
         .await?;
 
-    Ok(BorrowerOverview {
-        collateral_locked: asset_amounts_from_rows(collateral_rows),
-        borrowings: asset_amounts_from_rows(borrowings_rows),
+    Ok(LenderOverview {
+        supplied_loans: asset_amounts_from_rows(supplied_rows),
+        interest_outstanding: asset_amounts_from_rows(interest_rows),
         active_loans: counts.active_loans as u64,
-        pending_offers: counts.pending_offers as u64,
+        to_be_claimed: counts.to_be_claimed as u64,
     })
 }
 
@@ -131,7 +131,7 @@ pub async fn fetch_offer_list(
         QueryBuilder::new("SELECT COUNT(*)::BIGINT FROM offers WHERE 1=1");
     push_latest_participant_offers_scope(
         &mut count_builder,
-        ParticipantType::Borrower,
+        ParticipantType::Lender,
         script_pubkey,
     );
     apply_offer_list_filters(&mut count_builder, query);
@@ -157,7 +157,7 @@ pub async fn fetch_offer_list(
     );
     push_latest_participant_offers_scope(
         &mut query_builder,
-        ParticipantType::Borrower,
+        ParticipantType::Lender,
         script_pubkey,
     );
     apply_offer_list_filters(&mut query_builder, query);

--- a/crates/indexer/src/api/lenders/db.rs
+++ b/crates/indexer/src/api/lenders/db.rs
@@ -2,7 +2,9 @@ use sqlx::{PgPool, Postgres, QueryBuilder};
 
 use crate::api::OfferListQuery;
 use crate::api::borrowers::dto::AssetAmount;
-use crate::api::offers::db::{apply_offer_list_filters, push_offer_list_order_by};
+use crate::api::offers::db::{
+    apply_offer_list_filters, enrich_offer_list_items, push_offer_list_order_by,
+};
 use crate::api::offers::dto::{OfferListItemShort, OfferListResponse};
 use crate::api::participants::push_latest_participant_offers_scope;
 use crate::api::utils::{format_hex, format_satoshis};
@@ -172,7 +174,9 @@ pub async fn fetch_offer_list(
         .fetch_all(db)
         .await?;
 
-    let items = rows.into_iter().map(OfferListItemShort::from).collect();
+    let mut items: Vec<OfferListItemShort> =
+        rows.into_iter().map(OfferListItemShort::from).collect();
+    enrich_offer_list_items(db, &mut items).await?;
 
     Ok(OfferListResponse {
         items,

--- a/crates/indexer/src/api/lenders/dto.rs
+++ b/crates/indexer/src/api/lenders/dto.rs
@@ -1,0 +1,12 @@
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use crate::api::borrowers::dto::AssetAmount;
+
+#[derive(Serialize, ToSchema)]
+pub struct LenderOverview {
+    pub supplied_loans: Vec<AssetAmount>,
+    pub interest_outstanding: Vec<AssetAmount>,
+    pub active_loans: u64,
+    pub to_be_claimed: u64,
+}

--- a/crates/indexer/src/api/lenders/handlers.rs
+++ b/crates/indexer/src/api/lenders/handlers.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+
+use axum::{
+    Json,
+    extract::{Query, State},
+};
+
+use crate::api::offers::dto::OfferListResponse;
+use crate::api::openapi::{ErrorResponse, LenderOffersParams, LenderOverviewParams};
+use crate::api::utils::parse_script_pubkey;
+use crate::api::{ApiError, AppState};
+
+use super::dto::LenderOverview;
+use super::params::{LenderOffersQuery, LenderOverviewQuery};
+
+#[utoipa::path(
+    get,
+    path = "/lenders/overview",
+    tag = "lenders",
+    params(LenderOverviewParams),
+    responses(
+        (status = 200, description = "Lender overview totals", body = LenderOverview),
+        (status = 400, description = "Invalid script_pubkey hex", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse),
+    )
+)]
+#[tracing::instrument(name = "Getting lender overview by script", skip(state, query))]
+pub async fn get_overview_by_script(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<LenderOverviewQuery>,
+) -> Result<Json<LenderOverview>, ApiError> {
+    let script_bytes = parse_script_pubkey(&query.script_pubkey)?;
+
+    let overview = super::db::fetch_overview(&state.db, &script_bytes).await?;
+
+    Ok(Json(overview))
+}
+
+#[utoipa::path(
+    get,
+    path = "/lenders/offers",
+    tag = "lenders",
+    params(LenderOffersParams),
+    responses(
+        (status = 200, description = "Paginated short offer list for the lender", body = OfferListResponse),
+        (status = 400, description = "Invalid query parameters", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse),
+    )
+)]
+#[tracing::instrument(name = "Getting lender offers by script", skip(state, query))]
+pub async fn list_offers_by_script(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<LenderOffersQuery>,
+) -> Result<Json<OfferListResponse>, ApiError> {
+    let script_bytes = parse_script_pubkey(&query.script_pubkey)?;
+
+    let offers = super::db::fetch_offer_list(&state.db, &script_bytes, &query.filters).await?;
+
+    Ok(Json(offers))
+}

--- a/crates/indexer/src/api/lenders/handlers.rs
+++ b/crates/indexer/src/api/lenders/handlers.rs
@@ -17,6 +17,7 @@ use super::params::{LenderOffersQuery, LenderOverviewQuery};
     get,
     path = "/lenders/overview",
     tag = "lenders",
+    operation_id = "get_lender_overview_by_script",
     params(LenderOverviewParams),
     responses(
         (status = 200, description = "Lender overview totals", body = LenderOverview),
@@ -40,6 +41,7 @@ pub async fn get_overview_by_script(
     get,
     path = "/lenders/offers",
     tag = "lenders",
+    operation_id = "list_lender_offers_by_script",
     params(LenderOffersParams),
     responses(
         (status = 200, description = "Paginated short offer list for the lender", body = OfferListResponse),

--- a/crates/indexer/src/api/lenders/mod.rs
+++ b/crates/indexer/src/api/lenders/mod.rs
@@ -1,0 +1,7 @@
+mod db;
+pub(crate) mod dto;
+pub(crate) mod handlers;
+mod params;
+mod routes;
+
+pub use routes::routes;

--- a/crates/indexer/src/api/lenders/params.rs
+++ b/crates/indexer/src/api/lenders/params.rs
@@ -1,0 +1,34 @@
+use serde::Deserialize;
+
+use crate::api::params::OfferFilters;
+use crate::api::params::ScriptQuery;
+
+/// Query parameters for `GET /lenders/overview`.
+pub type LenderOverviewQuery = ScriptQuery;
+
+/// Query parameters for `GET /lenders/offers`: wallet script plus offer-list filters.
+#[derive(Deserialize, Debug)]
+pub struct LenderOffersQuery {
+    pub script_pubkey: String,
+    #[serde(flatten)]
+    pub filters: OfferFilters,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LenderOffersQuery;
+
+    #[test]
+    fn lender_offers_query_parses_flat_pagination() {
+        let parsed: LenderOffersQuery = serde_urlencoded::from_str(
+            "script_pubkey=0014d0c4a3ef09e887b6e99e397e518fe3e41a118ca1&limit=10",
+        )
+        .expect("parse lender offers query");
+
+        assert_eq!(
+            parsed.script_pubkey,
+            "0014d0c4a3ef09e887b6e99e397e518fe3e41a118ca1"
+        );
+        assert_eq!(parsed.filters.limit, Some(10));
+    }
+}

--- a/crates/indexer/src/api/lenders/routes.rs
+++ b/crates/indexer/src/api/lenders/routes.rs
@@ -1,0 +1,13 @@
+use std::sync::Arc;
+
+use axum::{Router, routing::get};
+
+use crate::api::AppState;
+
+use super::handlers;
+
+pub fn routes() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/lenders/overview", get(handlers::get_overview_by_script))
+        .route("/lenders/offers", get(handlers::list_offers_by_script))
+}

--- a/crates/indexer/src/api/mod.rs
+++ b/crates/indexer/src/api/mod.rs
@@ -1,9 +1,11 @@
 mod borrowers;
 mod error;
 mod factories;
+mod lenders;
 mod offers;
 mod openapi;
 mod params;
+mod participants;
 pub mod server;
 mod state;
 pub mod utils;

--- a/crates/indexer/src/api/offers/db.rs
+++ b/crates/indexer/src/api/offers/db.rs
@@ -3,7 +3,7 @@ use sqlx::{PgPool, Postgres, QueryBuilder};
 use std::collections::HashMap;
 use uuid::Uuid;
 
-use crate::api::utils::{format_hex, parse_filter_hex};
+use crate::api::utils::{format_hex, format_satoshis, parse_filter_hex};
 use crate::api::{OfferListQuery, SortDir};
 use crate::models::{
     OfferModel, OfferModelShort, OfferParticipantModel, OfferStatus, OfferUtxoModel,
@@ -12,8 +12,27 @@ use crate::models::{
 
 use super::dto::{
     OfferDetailsResponse, OfferListItemFull, OfferListItemShort, OfferListResponse, OfferUtxoDto,
-    OfferUtxoOutpointShort, ParticipantDto, ParticipantShort,
+    OfferUtxoOutpointShort, OffersOverview, ParticipantDto, ParticipantShort,
 };
+
+use crate::api::borrowers::dto::AssetAmount;
+
+#[derive(sqlx::FromRow)]
+struct AssetSumRow {
+    asset_id: Vec<u8>,
+    amount: i64,
+}
+
+fn asset_amounts_from_rows(rows: Vec<AssetSumRow>) -> Vec<AssetAmount> {
+    rows.into_iter()
+        .map(|row| AssetAmount {
+            asset: format_hex(row.asset_id),
+            amount: format_satoshis(row.amount),
+        })
+        .collect()
+}
+
+const OPEN_COLLATERAL_STATUSES: [OfferStatus; 2] = [OfferStatus::Pending, OfferStatus::Active];
 
 #[derive(sqlx::FromRow)]
 struct ParticipantListRow {
@@ -100,6 +119,47 @@ pub(crate) async fn enrich_offer_list_items(
     }
 
     Ok(())
+}
+
+#[tracing::instrument(name = "Fetching offers overview from DB", skip(db))]
+pub async fn fetch_overview(db: &PgPool) -> Result<OffersOverview, sqlx::Error> {
+    let (collateral_rows, principal_rows, active_loans_count) = tokio::try_join!(
+        sqlx::query_as::<_, AssetSumRow>(
+            r#"
+            SELECT collateral_asset_id AS asset_id, SUM(collateral_amount)::BIGINT AS amount
+            FROM offers
+            WHERE current_status = ANY($1)
+            GROUP BY collateral_asset_id
+            "#,
+        )
+        .bind(OPEN_COLLATERAL_STATUSES)
+        .fetch_all(db),
+        sqlx::query_as::<_, AssetSumRow>(
+            r#"
+            SELECT principal_asset_id AS asset_id, SUM(principal_amount)::BIGINT AS amount
+            FROM offers
+            WHERE current_status = $1
+            GROUP BY principal_asset_id
+            "#,
+        )
+        .bind(OfferStatus::Active)
+        .fetch_all(db),
+        sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT COUNT(*)::BIGINT
+            FROM offers
+            WHERE current_status = $1
+            "#,
+        )
+        .bind(OfferStatus::Active)
+        .fetch_one(db),
+    )?;
+
+    Ok(OffersOverview {
+        collateral_locked: asset_amounts_from_rows(collateral_rows),
+        active_loan_principal: asset_amounts_from_rows(principal_rows),
+        active_loans_count: active_loans_count as u64,
+    })
 }
 
 pub(crate) fn apply_offer_list_filters<'a>(

--- a/crates/indexer/src/api/offers/db.rs
+++ b/crates/indexer/src/api/offers/db.rs
@@ -1,8 +1,9 @@
 use simplex::simplicityhl::elements::hex::ToHex;
 use sqlx::{PgPool, Postgres, QueryBuilder};
+use std::collections::HashMap;
 use uuid::Uuid;
 
-use crate::api::utils::parse_filter_hex;
+use crate::api::utils::{format_hex, parse_filter_hex};
 use crate::api::{OfferListQuery, SortDir};
 use crate::models::{
     OfferModel, OfferModelShort, OfferParticipantModel, OfferStatus, OfferUtxoModel,
@@ -11,8 +12,95 @@ use crate::models::{
 
 use super::dto::{
     OfferDetailsResponse, OfferListItemFull, OfferListItemShort, OfferListResponse, OfferUtxoDto,
-    ParticipantDto,
+    OfferUtxoOutpointShort, ParticipantDto, ParticipantShort,
 };
+
+#[derive(sqlx::FromRow)]
+struct ParticipantListRow {
+    offer_id: Uuid,
+    participant_type: ParticipantType,
+    script_pubkey: Vec<u8>,
+}
+
+#[derive(sqlx::FromRow)]
+struct BorrowerPrincipalListRow {
+    offer_id: Uuid,
+    txid: Vec<u8>,
+    vout: i32,
+}
+
+pub(crate) async fn enrich_offer_list_items(
+    db: &PgPool,
+    items: &mut [OfferListItemShort],
+) -> Result<(), sqlx::Error> {
+    if items.is_empty() {
+        return Ok(());
+    }
+
+    let offer_ids: Vec<Uuid> = items.iter().map(|item| item.id).collect();
+
+    let participant_rows = sqlx::query_as::<_, ParticipantListRow>(
+        r#"
+        SELECT DISTINCT ON (offer_id, participant_type)
+            offer_id,
+            participant_type,
+            script_pubkey
+        FROM offer_participants
+        WHERE offer_id = ANY($1)
+        ORDER BY offer_id, participant_type, created_at_height DESC
+        "#,
+    )
+    .bind(&offer_ids)
+    .fetch_all(db)
+    .await?;
+
+    let principal_rows = sqlx::query_as::<_, BorrowerPrincipalListRow>(
+        r#"
+        SELECT offer_id, txid, vout
+        FROM offer_utxos
+        WHERE spent_txid IS NULL
+          AND utxo_type = $1
+          AND offer_id = ANY($2)
+        "#,
+    )
+    .bind(UtxoType::BorrowerPrincipal)
+    .bind(&offer_ids)
+    .fetch_all(db)
+    .await?;
+
+    let mut participants_by_offer: HashMap<Uuid, Vec<ParticipantShort>> = HashMap::new();
+    for row in participant_rows {
+        participants_by_offer
+            .entry(row.offer_id)
+            .or_default()
+            .push(ParticipantShort {
+                participant_type: row.participant_type,
+                script_pubkey: row.script_pubkey.to_hex(),
+            });
+    }
+
+    for participants in participants_by_offer.values_mut() {
+        participants.sort_by_key(|participant| participant.participant_type);
+    }
+
+    let mut principal_by_offer: HashMap<Uuid, OfferUtxoOutpointShort> = HashMap::new();
+    for row in principal_rows {
+        principal_by_offer.insert(
+            row.offer_id,
+            OfferUtxoOutpointShort {
+                txid: format_hex(row.txid),
+                vout: row.vout as u32,
+            },
+        );
+    }
+
+    for item in items.iter_mut() {
+        item.participants = participants_by_offer.remove(&item.id).unwrap_or_default();
+        item.borrower_principal_utxo = principal_by_offer.remove(&item.id);
+    }
+
+    Ok(())
+}
 
 pub(crate) fn apply_offer_list_filters<'a>(
     query_builder: &mut QueryBuilder<'a, Postgres>,
@@ -125,7 +213,9 @@ pub async fn fetch_list(
         .fetch_all(db)
         .await?;
 
-    let items = rows.into_iter().map(OfferListItemShort::from).collect();
+    let mut items: Vec<OfferListItemShort> =
+        rows.into_iter().map(OfferListItemShort::from).collect();
+    enrich_offer_list_items(db, &mut items).await?;
 
     Ok(OfferListResponse {
         items,

--- a/crates/indexer/src/api/offers/dto.rs
+++ b/crates/indexer/src/api/offers/dto.rs
@@ -292,6 +292,26 @@ mod tests {
     }
 
     #[test]
+    fn offer_utxo_dto_from_model_handles_unspent_borrower_principal() {
+        let model = OfferUtxoModel {
+            offer_id: Uuid::new_v4(),
+            txid: vec![0x22],
+            vout: 1,
+            utxo_type: UtxoType::BorrowerPrincipal,
+            created_at_height: 2,
+            spent_txid: None,
+            spent_at_height: None,
+        };
+
+        let dto = OfferUtxoDto::from(model);
+
+        assert_eq!(dto.vout, 1);
+        assert_eq!(dto.utxo_type, UtxoType::BorrowerPrincipal);
+        assert_eq!(dto.spent_txid, None);
+        assert_eq!(dto.spent_at_height, None);
+    }
+
+    #[test]
     fn offer_utxo_dto_from_model_handles_unspent_utxo() {
         let model = OfferUtxoModel {
             offer_id: Uuid::new_v4(),

--- a/crates/indexer/src/api/offers/dto.rs
+++ b/crates/indexer/src/api/offers/dto.rs
@@ -4,6 +4,7 @@ use uuid::Uuid;
 
 use simplex::simplicityhl::elements::hex::ToHex;
 
+use crate::api::borrowers::dto::AssetAmount;
 use crate::api::utils::{format_hex, format_satoshis};
 use crate::models::{
     OfferModel, OfferModelShort, OfferParticipantModel, OfferStatus, OfferUtxoModel,
@@ -70,6 +71,13 @@ pub struct OfferListResponse {
     pub total: u64,
     pub limit: u64,
     pub offset: u64,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct OffersOverview {
+    pub collateral_locked: Vec<AssetAmount>,
+    pub active_loan_principal: Vec<AssetAmount>,
+    pub active_loans_count: u64,
 }
 
 impl From<OfferModelShort> for OfferListItemShort {

--- a/crates/indexer/src/api/offers/dto.rs
+++ b/crates/indexer/src/api/offers/dto.rs
@@ -11,6 +11,36 @@ use crate::models::{
 };
 
 #[derive(Serialize, ToSchema)]
+pub struct ParticipantShort {
+    pub participant_type: ParticipantType,
+    pub script_pubkey: String,
+}
+
+impl From<&OfferParticipantModel> for ParticipantShort {
+    fn from(value: &OfferParticipantModel) -> Self {
+        Self {
+            participant_type: value.participant_type,
+            script_pubkey: value.script_pubkey.to_hex(),
+        }
+    }
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct OfferUtxoOutpointShort {
+    pub txid: String,
+    pub vout: u32,
+}
+
+impl From<&OfferUtxoModel> for OfferUtxoOutpointShort {
+    fn from(value: &OfferUtxoModel) -> Self {
+        Self {
+            txid: format_hex(value.txid.clone()),
+            vout: value.vout as u32,
+        }
+    }
+}
+
+#[derive(Serialize, ToSchema)]
 pub struct OfferListItemShort {
     pub id: Uuid,
     pub issuance_factory_id: Uuid,
@@ -29,6 +59,9 @@ pub struct OfferListItemShort {
     pub loan_expiration_height: u32,
     pub created_at_height: u64,
     pub created_at_txid: String,
+    pub participants: Vec<ParticipantShort>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub borrower_principal_utxo: Option<OfferUtxoOutpointShort>,
 }
 
 #[derive(Serialize, ToSchema)]
@@ -53,6 +86,8 @@ impl From<OfferModelShort> for OfferListItemShort {
             loan_expiration_height: value.loan_expiration_time as u32,
             created_at_height: value.created_at_height as u64,
             created_at_txid: format_hex(value.created_at_txid),
+            participants: Vec::new(),
+            borrower_principal_utxo: None,
         }
     }
 }
@@ -82,6 +117,8 @@ impl From<OfferModel> for OfferListItemFull {
                 loan_expiration_height: value.loan_expiration_time as u32,
                 created_at_height: value.created_at_height as u64,
                 created_at_txid: format_hex(value.created_at_txid),
+                participants: Vec::new(),
+                borrower_principal_utxo: None,
             },
             borrower_nft_asset: format_hex(value.borrower_nft_asset_id),
             lender_nft_asset: format_hex(value.lender_nft_asset_id),
@@ -152,7 +189,10 @@ pub struct OfferDetailsResponse {
 
 #[cfg(test)]
 mod tests {
-    use super::{OfferListItemFull, OfferListItemShort, OfferUtxoDto, ParticipantDto};
+    use super::{
+        OfferListItemFull, OfferListItemShort, OfferUtxoDto, OfferUtxoOutpointShort,
+        ParticipantDto, ParticipantShort,
+    };
     use crate::models::{
         OfferModel, OfferModelShort, OfferParticipantModel, OfferStatus, OfferUtxoModel,
         ParticipantType, UtxoType,
@@ -188,6 +228,45 @@ mod tests {
         assert_eq!(dto.loan_expiration_height, 123);
         assert_eq!(dto.created_at_height, 456);
         assert_eq!(dto.created_at_txid, "ccbbaa");
+        assert!(dto.participants.is_empty());
+        assert!(dto.borrower_principal_utxo.is_none());
+    }
+
+    #[test]
+    fn participant_short_from_model_maps_type_and_script() {
+        let model = OfferParticipantModel {
+            offer_id: Uuid::new_v4(),
+            participant_type: ParticipantType::Borrower,
+            script_pubkey: vec![0x52, 0xac],
+            txid: vec![0x01],
+            vout: 3,
+            created_at_height: 1,
+            spent_txid: None,
+            spent_at_height: None,
+        };
+
+        let dto = ParticipantShort::from(&model);
+
+        assert_eq!(dto.participant_type, ParticipantType::Borrower);
+        assert_eq!(dto.script_pubkey, "52ac");
+    }
+
+    #[test]
+    fn offer_utxo_outpoint_short_from_model_maps_txid_and_vout() {
+        let model = OfferUtxoModel {
+            offer_id: Uuid::new_v4(),
+            txid: vec![0xab, 0xcd],
+            vout: 1,
+            utxo_type: UtxoType::BorrowerPrincipal,
+            created_at_height: 2,
+            spent_txid: None,
+            spent_at_height: None,
+        };
+
+        let dto = OfferUtxoOutpointShort::from(&model);
+
+        assert_eq!(dto.txid, "cdab");
+        assert_eq!(dto.vout, 1);
     }
 
     #[test]

--- a/crates/indexer/src/api/offers/handlers.rs
+++ b/crates/indexer/src/api/offers/handlers.rs
@@ -11,7 +11,26 @@ use crate::api::params::ScriptQuery;
 use crate::api::utils::parse_script_pubkey;
 use crate::api::{ApiError, AppState, OfferListQuery};
 
-use super::dto::{OfferDetailsResponse, OfferListResponse};
+use super::dto::{OfferDetailsResponse, OfferListResponse, OffersOverview};
+
+#[utoipa::path(
+    get,
+    path = "/offers/overview",
+    tag = "offers",
+    operation_id = "get_offers_overview",
+    responses(
+        (status = 200, description = "Protocol-wide active loan totals", body = OffersOverview),
+        (status = 500, description = "Internal server error", body = ErrorResponse),
+    )
+)]
+#[tracing::instrument(name = "Getting offers overview", skip(state))]
+pub async fn get_overview(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<OffersOverview>, ApiError> {
+    let overview = super::db::fetch_overview(&state.db).await?;
+
+    Ok(Json(overview))
+}
 
 #[utoipa::path(
     get,

--- a/crates/indexer/src/api/offers/routes.rs
+++ b/crates/indexer/src/api/offers/routes.rs
@@ -8,7 +8,8 @@ use super::handlers;
 
 pub fn routes() -> Router<Arc<AppState>> {
     Router::new()
-        .route("/offers", get(handlers::list_offers))
+        .route("/offers/overview", get(handlers::get_overview))
         .route("/offers/by-script", get(handlers::get_ids_by_script))
         .route("/offers/{id}", get(handlers::get_details))
+        .route("/offers", get(handlers::list_offers))
 }

--- a/crates/indexer/src/api/openapi/doc.rs
+++ b/crates/indexer/src/api/openapi/doc.rs
@@ -3,7 +3,7 @@ use utoipa::OpenApi;
 #[cfg(feature = "swagger-ui")]
 use utoipa_swagger_ui::SwaggerUi;
 
-use crate::api::borrowers::dto::{AssetAmount, BorrowerDashboardResponse, BorrowerOverview};
+use crate::api::borrowers::dto::{AssetAmount, BorrowerOverview};
 use crate::api::borrowers::handlers as borrower_handlers;
 use crate::api::factories::dto::{
     FactoryAuthUtxoDto, FactoryDetailsResponse, FactoryProgramUtxoDto,
@@ -29,13 +29,13 @@ use super::schemas::{ErrorBody, ErrorResponse, OfferDetailsResponseSchema};
         offer_handlers::list_offers,
         offer_handlers::get_ids_by_script,
         offer_handlers::get_details,
-        borrower_handlers::get_by_script,
+        borrower_handlers::get_overview_by_script,
+        borrower_handlers::list_offers_by_script,
         factory_handlers::get_by_script,
         factory_handlers::get_by_id,
     ),
     components(schemas(
         AssetAmount,
-        BorrowerDashboardResponse,
         BorrowerOverview,
         ErrorBody,
         ErrorResponse,
@@ -56,7 +56,7 @@ use super::schemas::{ErrorBody, ErrorResponse, OfferDetailsResponseSchema};
     )),
     tags(
         (name = "offers", description = "Lending offer queries"),
-        (name = "borrowers", description = "Borrower dashboard"),
+        (name = "borrowers", description = "Borrower queries"),
         (name = "factories", description = "Issuance factory queries"),
     )
 )]
@@ -80,7 +80,8 @@ mod tests {
         assert!(paths.contains_key("/offers"));
         assert!(paths.contains_key("/offers/by-script"));
         assert!(paths.contains_key("/offers/{id}"));
-        assert!(paths.contains_key("/borrowers/by-script"));
+        assert!(paths.contains_key("/borrowers/overview"));
+        assert!(paths.contains_key("/borrowers/offers"));
         assert!(paths.contains_key("/factories/by-script"));
         assert!(paths.contains_key("/factories/{id}"));
     }
@@ -99,13 +100,13 @@ mod tests {
     }
 
     #[test]
-    fn borrower_by_script_has_flat_query_params() {
+    fn borrower_offers_has_flat_query_params() {
         let spec = ApiDoc::openapi();
         let path = spec
             .paths
             .paths
-            .get("/borrowers/by-script")
-            .expect("borrowers path");
+            .get("/borrowers/offers")
+            .expect("borrowers offers path");
         let get = path.get.as_ref().expect("GET operation");
         let params = get.parameters.as_ref().expect("query parameters");
 

--- a/crates/indexer/src/api/openapi/doc.rs
+++ b/crates/indexer/src/api/openapi/doc.rs
@@ -127,4 +127,35 @@ mod tests {
         assert!(names.contains(&"status".to_string()));
         assert!(!names.iter().any(|n| n == "filters"));
     }
+
+    #[test]
+    fn openapi_operation_ids_are_unique() {
+        let spec = ApiDoc::openapi();
+        let mut seen = std::collections::HashMap::<String, String>::new();
+
+        for (path, item) in &spec.paths.paths {
+            let operations = [
+                ("get", item.get.as_ref()),
+                ("post", item.post.as_ref()),
+                ("put", item.put.as_ref()),
+                ("patch", item.patch.as_ref()),
+                ("delete", item.delete.as_ref()),
+            ];
+
+            for (method, operation) in operations {
+                let Some(operation) = operation else {
+                    continue;
+                };
+
+                let operation_id = operation
+                    .operation_id
+                    .as_ref()
+                    .unwrap_or_else(|| panic!("{method} {path} must declare operation_id"));
+
+                if let Some(previous_path) = seen.insert(operation_id.clone(), path.clone()) {
+                    panic!("duplicate operation_id `{operation_id}` on {path} and {previous_path}");
+                }
+            }
+        }
+    }
 }

--- a/crates/indexer/src/api/openapi/doc.rs
+++ b/crates/indexer/src/api/openapi/doc.rs
@@ -12,8 +12,8 @@ use crate::api::factories::handlers as factory_handlers;
 use crate::api::lenders::dto::LenderOverview;
 use crate::api::lenders::handlers as lender_handlers;
 use crate::api::offers::dto::{
-    OfferListItemShort, OfferListResponse, OfferUtxoDto, OfferUtxoOutpointShort, ParticipantDto,
-    ParticipantShort,
+    OfferListItemShort, OfferListResponse, OfferUtxoDto, OfferUtxoOutpointShort, OffersOverview,
+    ParticipantDto, ParticipantShort,
 };
 use crate::api::offers::handlers as offer_handlers;
 use crate::api::params::{OfferSortBy, SortDir};
@@ -29,6 +29,7 @@ use super::schemas::{ErrorBody, ErrorResponse, OfferDetailsResponseSchema};
         description = "REST API for the Simplicity Lending protocol indexer."
     ),
     paths(
+        offer_handlers::get_overview,
         offer_handlers::list_offers,
         offer_handlers::get_ids_by_script,
         offer_handlers::get_details,
@@ -52,6 +53,7 @@ use super::schemas::{ErrorBody, ErrorResponse, OfferDetailsResponseSchema};
         OfferDetailsResponseSchema,
         OfferListItemShort,
         OfferListResponse,
+        OffersOverview,
         OfferSortBy,
         OfferStatus,
         OfferUtxoDto,
@@ -87,6 +89,7 @@ mod tests {
         let paths = spec.paths.paths;
 
         assert!(paths.contains_key("/offers"));
+        assert!(paths.contains_key("/offers/overview"));
         assert!(paths.contains_key("/offers/by-script"));
         assert!(paths.contains_key("/offers/{id}"));
         assert!(paths.contains_key("/borrowers/overview"));

--- a/crates/indexer/src/api/openapi/doc.rs
+++ b/crates/indexer/src/api/openapi/doc.rs
@@ -12,7 +12,8 @@ use crate::api::factories::handlers as factory_handlers;
 use crate::api::lenders::dto::LenderOverview;
 use crate::api::lenders::handlers as lender_handlers;
 use crate::api::offers::dto::{
-    OfferListItemShort, OfferListResponse, OfferUtxoDto, ParticipantDto,
+    OfferListItemShort, OfferListResponse, OfferUtxoDto, OfferUtxoOutpointShort, ParticipantDto,
+    ParticipantShort,
 };
 use crate::api::offers::handlers as offer_handlers;
 use crate::api::params::{OfferSortBy, SortDir};
@@ -54,7 +55,9 @@ use super::schemas::{ErrorBody, ErrorResponse, OfferDetailsResponseSchema};
         OfferSortBy,
         OfferStatus,
         OfferUtxoDto,
+        OfferUtxoOutpointShort,
         ParticipantDto,
+        ParticipantShort,
         ParticipantType,
         SortDir,
         UtxoType,

--- a/crates/indexer/src/api/openapi/doc.rs
+++ b/crates/indexer/src/api/openapi/doc.rs
@@ -9,6 +9,8 @@ use crate::api::factories::dto::{
     FactoryAuthUtxoDto, FactoryDetailsResponse, FactoryProgramUtxoDto,
 };
 use crate::api::factories::handlers as factory_handlers;
+use crate::api::lenders::dto::LenderOverview;
+use crate::api::lenders::handlers as lender_handlers;
 use crate::api::offers::dto::{
     OfferListItemShort, OfferListResponse, OfferUtxoDto, ParticipantDto,
 };
@@ -31,6 +33,8 @@ use super::schemas::{ErrorBody, ErrorResponse, OfferDetailsResponseSchema};
         offer_handlers::get_details,
         borrower_handlers::get_overview_by_script,
         borrower_handlers::list_offers_by_script,
+        lender_handlers::get_overview_by_script,
+        lender_handlers::list_offers_by_script,
         factory_handlers::get_by_script,
         factory_handlers::get_by_id,
     ),
@@ -43,6 +47,7 @@ use super::schemas::{ErrorBody, ErrorResponse, OfferDetailsResponseSchema};
         FactoryDetailsResponse,
         FactoryProgramUtxoDto,
         FactoryStatus,
+        LenderOverview,
         OfferDetailsResponseSchema,
         OfferListItemShort,
         OfferListResponse,
@@ -57,6 +62,7 @@ use super::schemas::{ErrorBody, ErrorResponse, OfferDetailsResponseSchema};
     tags(
         (name = "offers", description = "Lending offer queries"),
         (name = "borrowers", description = "Borrower queries"),
+        (name = "lenders", description = "Lender queries"),
         (name = "factories", description = "Issuance factory queries"),
     )
 )]
@@ -82,6 +88,8 @@ mod tests {
         assert!(paths.contains_key("/offers/{id}"));
         assert!(paths.contains_key("/borrowers/overview"));
         assert!(paths.contains_key("/borrowers/offers"));
+        assert!(paths.contains_key("/lenders/overview"));
+        assert!(paths.contains_key("/lenders/offers"));
         assert!(paths.contains_key("/factories/by-script"));
         assert!(paths.contains_key("/factories/{id}"));
     }

--- a/crates/indexer/src/api/openapi/mod.rs
+++ b/crates/indexer/src/api/openapi/mod.rs
@@ -3,5 +3,8 @@ mod params;
 mod schemas;
 
 pub use doc::{ApiDoc, swagger_routes};
-pub use params::{BorrowerOffersParams, BorrowerOverviewParams, OfferListParams};
+pub use params::{
+    BorrowerOffersParams, BorrowerOverviewParams, LenderOffersParams, LenderOverviewParams,
+    OfferListParams,
+};
 pub use schemas::{ErrorResponse, OfferDetailsResponseSchema};

--- a/crates/indexer/src/api/openapi/mod.rs
+++ b/crates/indexer/src/api/openapi/mod.rs
@@ -3,5 +3,5 @@ mod params;
 mod schemas;
 
 pub use doc::{ApiDoc, swagger_routes};
-pub use params::{BorrowerDashboardParams, OfferListParams};
+pub use params::{BorrowerOffersParams, BorrowerOverviewParams, OfferListParams};
 pub use schemas::{ErrorResponse, OfferDetailsResponseSchema};

--- a/crates/indexer/src/api/openapi/params.rs
+++ b/crates/indexer/src/api/openapi/params.rs
@@ -50,3 +50,27 @@ pub struct BorrowerOffersParams {
     pub sort_by: Option<OfferSortBy>,
     pub sort_dir: Option<SortDir>,
 }
+
+/// OpenAPI query parameters for `GET /lenders/overview` (flat query string).
+pub type LenderOverviewParams = ScriptQuery;
+
+/// OpenAPI query parameters for `GET /lenders/offers` (flat query string).
+#[derive(IntoParams)]
+#[into_params(parameter_in = Query)]
+pub struct LenderOffersParams {
+    /// Wallet script pubkey hex.
+    #[param(example = "00144f883a4bb668547b534ae815bc32628893b6f435")]
+    pub script_pubkey: String,
+    /// Comma-separated offer states, e.g. `pending,active`.
+    #[param(example = "pending,active")]
+    pub status: Option<String>,
+    pub collateral_asset: Option<String>,
+    pub principal_asset: Option<String>,
+    pub factory_id: Option<Uuid>,
+    #[param(minimum = 0, maximum = 100, example = 50)]
+    pub limit: Option<u64>,
+    #[param(minimum = 0, example = 0)]
+    pub offset: Option<u64>,
+    pub sort_by: Option<OfferSortBy>,
+    pub sort_dir: Option<SortDir>,
+}

--- a/crates/indexer/src/api/openapi/params.rs
+++ b/crates/indexer/src/api/openapi/params.rs
@@ -4,7 +4,7 @@
 use utoipa::IntoParams;
 use uuid::Uuid;
 
-use crate::api::params::{OfferSortBy, SortDir};
+use crate::api::params::{OfferSortBy, ScriptQuery, SortDir};
 
 /// OpenAPI query parameters for `GET /offers` (flat query string).
 #[derive(IntoParams)]
@@ -27,10 +27,13 @@ pub struct OfferListParams {
     pub sort_dir: Option<SortDir>,
 }
 
-/// OpenAPI query parameters for `GET /borrowers/by-script` (flat query string).
+/// OpenAPI query parameters for `GET /borrowers/overview` (flat query string).
+pub type BorrowerOverviewParams = ScriptQuery;
+
+/// OpenAPI query parameters for `GET /borrowers/offers` (flat query string).
 #[derive(IntoParams)]
 #[into_params(parameter_in = Query)]
-pub struct BorrowerDashboardParams {
+pub struct BorrowerOffersParams {
     /// Wallet script pubkey hex.
     #[param(example = "00144f883a4bb668547b534ae815bc32628893b6f435")]
     pub script_pubkey: String,

--- a/crates/indexer/src/api/participants/mod.rs
+++ b/crates/indexer/src/api/participants/mod.rs
@@ -1,0 +1,3 @@
+mod scope;
+
+pub use scope::push_latest_participant_offers_scope;

--- a/crates/indexer/src/api/participants/scope.rs
+++ b/crates/indexer/src/api/participants/scope.rs
@@ -1,0 +1,24 @@
+use sqlx::{Postgres, QueryBuilder};
+
+use crate::models::ParticipantType;
+
+pub fn push_latest_participant_offers_scope<'a>(
+    query_builder: &mut QueryBuilder<'a, Postgres>,
+    participant_type: ParticipantType,
+    script_pubkey: &'a [u8],
+) {
+    query_builder.push(" AND id IN (");
+    query_builder.push(
+        "SELECT offer_id FROM (
+            SELECT DISTINCT ON (offer_id) offer_id, script_pubkey
+            FROM offer_participants
+            WHERE participant_type = ",
+    );
+    query_builder.push_bind(participant_type);
+    query_builder.push(
+        " ORDER BY offer_id, created_at_height DESC
+        ) latest_participant WHERE script_pubkey = ",
+    );
+    query_builder.push_bind(script_pubkey);
+    query_builder.push(")");
+}

--- a/crates/indexer/src/api/server.rs
+++ b/crates/indexer/src/api/server.rs
@@ -9,6 +9,7 @@ use tower_http::trace::TraceLayer;
 
 use crate::api::borrowers;
 use crate::api::factories;
+use crate::api::lenders;
 use crate::api::offers;
 use crate::api::openapi;
 use crate::api::state::AppState;
@@ -18,6 +19,7 @@ pub async fn run_server(listener: TcpListener, db_pool: PgPool) {
 
     let app = Router::new()
         .merge(borrowers::routes())
+        .merge(lenders::routes())
         .merge(factories::routes())
         .merge(offers::routes());
 

--- a/crates/indexer/src/indexer/trackers/offers/core.rs
+++ b/crates/indexer/src/indexer/trackers/offers/core.rs
@@ -158,6 +158,16 @@ impl OffersTracker {
                 self.handle_repayment_claim(sql_tx, old_outpoint, offer_id, txid, block_height)
                     .await
             }
+            UtxoType::BorrowerPrincipal => {
+                self.handle_borrower_principal_spend(
+                    sql_tx,
+                    old_outpoint,
+                    offer_id,
+                    txid,
+                    block_height,
+                )
+                .await
+            }
             _ => {
                 tracing::warn!("Unexpected transition for UTXO type: {:?}", utxo_type);
 
@@ -245,6 +255,47 @@ impl OffersTracker {
             },
         );
 
+        let borrower_principal_outpoint = OutPoint { txid, vout: 1 };
+        let borrower_principal_utxo = OfferUtxoModel {
+            offer_id,
+            txid: borrower_principal_outpoint.txid.to_byte_array().to_vec(),
+            vout: borrower_principal_outpoint.vout as i32,
+            utxo_type: UtxoType::BorrowerPrincipal,
+            created_at_height: block_height as i64,
+            spent_at_height: None,
+            spent_txid: None,
+        };
+
+        insert_offer_utxo(sql_tx, &borrower_principal_utxo).await?;
+
+        self.cache.insert(
+            borrower_principal_outpoint,
+            OffersWatchEntry {
+                offer_id,
+                utxo_type: UtxoType::BorrowerPrincipal,
+            },
+        );
+
+        Ok(())
+    }
+
+    #[tracing::instrument(
+        name = "Handling borrower principal spend",
+        skip(self, sql_tx, old_outpoint, offer_id, txid, block_height),
+        fields(%offer_id, %txid, %block_height),
+    )]
+    async fn handle_borrower_principal_spend(
+        &mut self,
+        sql_tx: &mut DbTx<'_>,
+        old_outpoint: &OutPoint,
+        offer_id: Uuid,
+        txid: Txid,
+        block_height: u64,
+    ) -> anyhow::Result<()> {
+        spend_offer_utxo(sql_tx, old_outpoint, block_height, txid).await?;
+        self.cache.remove(old_outpoint);
+
+        tracing::info!(%offer_id, "Borrower principal UTXO spent");
         Ok(())
     }
 

--- a/crates/indexer/src/models/offer_participants.rs
+++ b/crates/indexer/src/models/offer_participants.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
     PartialEq,
     PartialOrd,
     Eq,
+    Ord,
     sqlx::Type,
     Serialize,
     Deserialize,

--- a/crates/indexer/src/models/offer_utxo.rs
+++ b/crates/indexer/src/models/offer_utxo.rs
@@ -18,6 +18,7 @@ use uuid::Uuid;
 pub enum UtxoType {
     PendingOffer,
     ActiveOffer,
+    BorrowerPrincipal,
     Cancellation,
     Repayment,
     Liquidation,

--- a/crates/indexer/tests/api_integration.rs
+++ b/crates/indexer/tests/api_integration.rs
@@ -19,6 +19,23 @@ use crate::common::{
     unique_32_bytes_from_uuid, unspent_offer_utxo, unspent_participant,
 };
 
+fn participant_script<'a>(item: &'a Value, role: &str) -> Option<&'a str> {
+    item["participants"]
+        .as_array()?
+        .iter()
+        .find(|participant| participant["participant_type"].as_str() == Some(role))?
+        .get("script_pubkey")?
+        .as_str()
+}
+
+fn find_list_item(items: &Value, offer_id: Uuid) -> Option<&Value> {
+    items.as_array()?.iter().find(|item| {
+        item.get("id")
+            .and_then(Value::as_str)
+            .is_some_and(|id| id == offer_id.to_string())
+    })
+}
+
 async fn start_api(pool: PgPool) -> anyhow::Result<(String, tokio::task::JoinHandle<()>)> {
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;
@@ -267,6 +284,16 @@ async fn get_offers_returns_all_seeded_offers_with_correct_status() -> anyhow::R
     assert_eq!(items[0]["status"], "active");
     assert_eq!(items[1]["id"], pending_offer.to_string());
     assert_eq!(items[1]["status"], "pending");
+
+    let active_item = find_list_item(items, active_offer).expect("active offer in list");
+    assert_eq!(participant_script(active_item, "borrower"), Some("52ac"));
+    assert_eq!(participant_script(active_item, "lender"), Some("53ac"));
+    assert_eq!(active_item["borrower_principal_utxo"]["vout"], 1);
+
+    let pending_item = find_list_item(items, pending_offer).expect("pending offer in list");
+    assert_eq!(participant_script(pending_item, "borrower"), Some("52ac"));
+    assert_eq!(participant_script(pending_item, "lender"), Some("50ac"));
+    assert!(pending_item.get("borrower_principal_utxo").is_none());
 
     server_handle.abort();
     Ok(())
@@ -720,11 +747,19 @@ async fn borrower_offers_returns_paginated_list_for_script() -> anyhow::Result<(
             .into_iter()
             .flatten()
             .all(|item| {
-                item.get("participants").is_none()
+                participant_script(item, "borrower") == Some("52ac")
                     && item["collateral_amount"].as_str() == Some("1000")
                     && item["principal_amount"].as_str() == Some("500")
             })
     );
+
+    let active_item = find_list_item(&offers["items"], active_offer).expect("active offer");
+    assert_eq!(participant_script(active_item, "lender"), Some("53ac"));
+    assert_eq!(active_item["borrower_principal_utxo"]["vout"], 1);
+
+    let pending_item = find_list_item(&offers["items"], pending_offer).expect("pending offer");
+    assert_eq!(participant_script(pending_item, "lender"), Some("50ac"));
+    assert!(pending_item.get("borrower_principal_utxo").is_none());
 
     let pending_only = get_json(
         &http,
@@ -852,6 +887,11 @@ async fn lender_offers_excludes_pending_without_matching_lender_script() -> anyh
     assert_eq!(offers["total"], 1);
     assert_eq!(offers["items"][0]["id"], active_offer.to_string());
     assert_ne!(offers["items"][0]["id"], pending_offer.to_string());
+    assert_eq!(
+        participant_script(&offers["items"][0], "lender"),
+        Some("53ac")
+    );
+    assert_eq!(offers["items"][0]["borrower_principal_utxo"]["vout"], 1);
 
     server_handle.abort();
     Ok(())
@@ -889,6 +929,15 @@ async fn lender_offers_returns_paginated_list_for_script() -> anyhow::Result<()>
 
     assert_eq!(offers["total"], 2);
     assert_ids_match_unordered(&offers["items"], &[active_offer, repaid_offer]);
+
+    for item in offers["items"].as_array().into_iter().flatten() {
+        assert_eq!(participant_script(item, "borrower"), Some("52ac"));
+        assert_eq!(participant_script(item, "lender"), Some("53ac"));
+    }
+    let active_item = find_list_item(&offers["items"], active_offer).expect("active offer");
+    assert_eq!(active_item["borrower_principal_utxo"]["vout"], 1);
+    let repaid_item = find_list_item(&offers["items"], repaid_offer).expect("repaid offer");
+    assert!(repaid_item.get("borrower_principal_utxo").is_none());
 
     let active_only = get_json(
         &http,

--- a/crates/indexer/tests/api_integration.rs
+++ b/crates/indexer/tests/api_integration.rs
@@ -96,6 +96,7 @@ fn assert_uuid_values_match_unordered(value: &Value, expected: &[Uuid]) {
 
 /// Canonical offer graph used across most list/detail tests:
 /// - spent pre-lock UTXO (vout 0) + current unspent lending UTXO (vout 2);
+/// - for active offers, unspent borrower principal AssetAuth (vout 1);
 /// - historical borrower participant (vout 1, `51ac`) + current
 ///   unspent borrower participant (vout 3, `52ac`).
 async fn seed_offer_graph(
@@ -134,6 +135,19 @@ async fn seed_offer_graph(
     );
     seed_offer_utxo_row(pool, &pre_lock).await?;
     seed_offer_utxo_row(pool, &lending).await?;
+
+    if status == OfferStatus::Active {
+        let borrower_principal = unspent_offer_utxo(
+            offer_id,
+            OutPoint {
+                txid: outpoint.txid,
+                vout: 1,
+            },
+            UtxoType::BorrowerPrincipal,
+            created_at_height + 2,
+        );
+        seed_offer_utxo_row(pool, &borrower_principal).await?;
+    }
 
     let old_borrower = spent_participant(
         offer_id,
@@ -578,6 +592,29 @@ async fn offer_details_full_dto_shape() -> anyhow::Result<()> {
     assert_eq!(dto.participants[0].script_pubkey, "52ac");
     assert_eq!(dto.participants[0].participant_type, "borrower");
     assert!(dto.participants[0].spent_txid.is_none());
+
+    server_handle.abort();
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn active_offer_details_includes_borrower_principal_utxo() -> anyhow::Result<()> {
+    let (base_url, server_handle, _pending, active_offer) = setup_seeded_api().await?;
+    let http = reqwest::Client::new();
+
+    let raw = get_json(&http, format!("{base_url}/offers/{active_offer}")).await?;
+    let dto: ExpectedOfferDetailsDto =
+        serde_json::from_value(raw).expect("response must match full DTO shape");
+
+    assert_eq!(dto.id, active_offer);
+    assert_eq!(dto.status, "active");
+    assert_eq!(dto.utxos.len(), 2);
+
+    let utxo_types: Vec<&str> = dto.utxos.iter().map(|u| u.utxo_type.as_str()).collect();
+    assert!(utxo_types.contains(&"active_offer"));
+    assert!(utxo_types.contains(&"borrower_principal"));
+    assert!(dto.utxos.iter().all(|u| u.spent_txid.is_none()));
 
     server_handle.abort();
     Ok(())

--- a/crates/indexer/tests/api_integration.rs
+++ b/crates/indexer/tests/api_integration.rs
@@ -301,6 +301,32 @@ async fn get_offers_returns_all_seeded_offers_with_correct_status() -> anyhow::R
 
 #[tokio::test]
 #[serial]
+async fn get_offers_overview_returns_active_totals_only() -> anyhow::Result<()> {
+    let (base_url, server_handle, _pending_offer, _active_offer) = setup_seeded_api().await?;
+    let http = reqwest::Client::new();
+
+    let overview = get_json(&http, format!("{base_url}/offers/overview")).await?;
+
+    assert_eq!(overview["active_loans_count"], 1);
+    assert_eq!(
+        overview["collateral_locked"].as_array().map_or(0, Vec::len),
+        1
+    );
+    assert_eq!(overview["collateral_locked"][0]["amount"], "2000");
+    assert_eq!(
+        overview["active_loan_principal"]
+            .as_array()
+            .map_or(0, Vec::len),
+        1
+    );
+    assert_eq!(overview["active_loan_principal"][0]["amount"], "500");
+
+    server_handle.abort();
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
 async fn get_offers_by_script_returns_only_owners_of_unspent_match() -> anyhow::Result<()> {
     let (base_url, server_handle, pending_offer, active_offer) = setup_seeded_api().await?;
     let http = reqwest::Client::new();

--- a/crates/indexer/tests/api_integration.rs
+++ b/crates/indexer/tests/api_integration.rs
@@ -98,7 +98,9 @@ fn assert_uuid_values_match_unordered(value: &Value, expected: &[Uuid]) {
 /// - spent pre-lock UTXO (vout 0) + current unspent lending UTXO (vout 2);
 /// - for active offers, unspent borrower principal AssetAuth (vout 1);
 /// - historical borrower participant (vout 1, `51ac`) + current
-///   unspent borrower participant (vout 3, `52ac`).
+///   unspent borrower participant (vout 3, `52ac`);
+/// - historical lender participant (vout 2, `51ad`) + current
+///   unspent lender participant (vout 4, `53ac` for active/repaid, `50ac` for pending).
 async fn seed_offer_graph(
     pool: &PgPool,
     factory_id: Uuid,
@@ -173,6 +175,35 @@ async fn seed_offer_graph(
     );
     seed_participant_utxo_row(pool, &old_borrower).await?;
     seed_participant_utxo_row(pool, &current_borrower).await?;
+
+    let current_lender_script = match status {
+        OfferStatus::Pending => vec![0x50, 0xac],
+        _ => vec![0x53, 0xac],
+    };
+    let old_lender = spent_participant(
+        offer_id,
+        ParticipantType::Lender,
+        OutPoint {
+            txid: outpoint.txid,
+            vout: 2,
+        },
+        vec![0x51, 0xad],
+        created_at_height,
+        created_at_height + 3,
+        0x88,
+    );
+    let current_lender = unspent_participant(
+        offer_id,
+        ParticipantType::Lender,
+        OutPoint {
+            txid: outpoint.txid,
+            vout: 4,
+        },
+        current_lender_script,
+        created_at_height + 4,
+    );
+    seed_participant_utxo_row(pool, &old_lender).await?;
+    seed_participant_utxo_row(pool, &current_lender).await?;
 
     Ok(())
 }
@@ -588,10 +619,17 @@ async fn offer_details_full_dto_shape() -> anyhow::Result<()> {
     assert_eq!(dto.utxos.len(), 1);
     assert_eq!(dto.utxos[0].utxo_type, "active_offer");
     assert!(dto.utxos[0].spent_txid.is_none());
-    assert_eq!(dto.participants.len(), 1);
-    assert_eq!(dto.participants[0].script_pubkey, "52ac");
-    assert_eq!(dto.participants[0].participant_type, "borrower");
-    assert!(dto.participants[0].spent_txid.is_none());
+    assert_eq!(dto.participants.len(), 2);
+    assert!(
+        dto.participants
+            .iter()
+            .any(|p| p.participant_type == "borrower" && p.script_pubkey == "52ac")
+    );
+    assert!(
+        dto.participants
+            .iter()
+            .any(|p| p.participant_type == "lender" && p.script_pubkey == "50ac")
+    );
 
     server_handle.abort();
     Ok(())
@@ -720,6 +758,145 @@ async fn borrower_overview_is_not_filtered_by_offer_list_params() -> anyhow::Res
     .await?;
     assert_eq!(overview["pending_offers"], 1);
     assert_eq!(overview["active_loans"], 1);
+
+    server_handle.abort();
+    Ok(())
+}
+
+const REPAID_OFFER_HEIGHT: i64 = 44;
+
+async fn setup_seeded_lender_api()
+-> anyhow::Result<(String, tokio::task::JoinHandle<()>, Uuid, Uuid)> {
+    let pool = test_pool().await?;
+
+    let factory_id = Uuid::new_v4();
+    let active_offer = Uuid::new_v4();
+    let repaid_offer = Uuid::new_v4();
+
+    let factory = factory_model(
+        factory_id,
+        FACTORY_CREATION_HEIGHT,
+        unique_32_bytes_from_uuid(factory_id),
+    );
+    seed_factory_row(&pool, &factory).await?;
+
+    seed_offer_graph(
+        &pool,
+        factory_id,
+        active_offer,
+        OfferStatus::Active,
+        ACTIVE_OFFER_HEIGHT,
+    )
+    .await?;
+    seed_offer_graph(
+        &pool,
+        factory_id,
+        repaid_offer,
+        OfferStatus::Repaid,
+        REPAID_OFFER_HEIGHT,
+    )
+    .await?;
+
+    let (base_url, server_handle) = start_api(pool).await?;
+    Ok((base_url, server_handle, active_offer, repaid_offer))
+}
+
+#[tokio::test]
+#[serial]
+async fn lender_overview_returns_active_and_repaid_totals() -> anyhow::Result<()> {
+    let (base_url, server_handle, _active, _repaid) = setup_seeded_lender_api().await?;
+    let http = reqwest::Client::new();
+
+    let overview = get_json(
+        &http,
+        format!("{base_url}/lenders/overview?script_pubkey=53ac"),
+    )
+    .await?;
+
+    assert_eq!(overview["active_loans"], 1);
+    assert_eq!(overview["to_be_claimed"], 1);
+    assert_eq!(overview["supplied_loans"].as_array().map_or(0, Vec::len), 1);
+    assert_eq!(overview["supplied_loans"][0]["amount"], "500");
+    assert_eq!(
+        overview["interest_outstanding"]
+            .as_array()
+            .map_or(0, Vec::len),
+        1
+    );
+    assert_eq!(overview["interest_outstanding"][0]["amount"], "6");
+
+    let unknown_wallet = get_json(
+        &http,
+        format!("{base_url}/lenders/overview?script_pubkey=dead"),
+    )
+    .await?;
+    assert_eq!(unknown_wallet["active_loans"], 0);
+    assert_eq!(unknown_wallet["to_be_claimed"], 0);
+
+    server_handle.abort();
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn lender_offers_excludes_pending_without_matching_lender_script() -> anyhow::Result<()> {
+    let (base_url, server_handle, pending_offer, active_offer) = setup_seeded_api().await?;
+    let http = reqwest::Client::new();
+
+    let offers = get_json(
+        &http,
+        format!("{base_url}/lenders/offers?script_pubkey=53ac"),
+    )
+    .await?;
+
+    assert_eq!(offers["total"], 1);
+    assert_eq!(offers["items"][0]["id"], active_offer.to_string());
+    assert_ne!(offers["items"][0]["id"], pending_offer.to_string());
+
+    server_handle.abort();
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn lender_overview_is_not_filtered_by_offer_list_params() -> anyhow::Result<()> {
+    let (base_url, server_handle, _active, _repaid) = setup_seeded_lender_api().await?;
+    let http = reqwest::Client::new();
+
+    let overview = get_json(
+        &http,
+        format!("{base_url}/lenders/overview?script_pubkey=53ac&status=active"),
+    )
+    .await?;
+    assert_eq!(overview["active_loans"], 1);
+    assert_eq!(overview["to_be_claimed"], 1);
+
+    server_handle.abort();
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn lender_offers_returns_paginated_list_for_script() -> anyhow::Result<()> {
+    let (base_url, server_handle, active_offer, repaid_offer) = setup_seeded_lender_api().await?;
+    let http = reqwest::Client::new();
+
+    let offers = get_json(
+        &http,
+        format!("{base_url}/lenders/offers?script_pubkey=53ac"),
+    )
+    .await?;
+
+    assert_eq!(offers["total"], 2);
+    assert_ids_match_unordered(&offers["items"], &[active_offer, repaid_offer]);
+
+    let active_only = get_json(
+        &http,
+        format!("{base_url}/lenders/offers?script_pubkey=53ac&status=active"),
+    )
+    .await?;
+    assert_eq!(active_only["total"], 1);
+    assert_eq!(active_only["items"][0]["id"], active_offer.to_string());
 
     server_handle.abort();
     Ok(())

--- a/crates/indexer/tests/api_integration.rs
+++ b/crates/indexer/tests/api_integration.rs
@@ -622,17 +622,16 @@ async fn active_offer_details_includes_borrower_principal_utxo() -> anyhow::Resu
 
 #[tokio::test]
 #[serial]
-async fn borrower_dashboard_returns_overview_and_filtered_offers() -> anyhow::Result<()> {
-    let (base_url, server_handle, pending_offer, active_offer) = setup_seeded_api().await?;
+async fn borrower_overview_returns_totals_for_script() -> anyhow::Result<()> {
+    let (base_url, server_handle, _pending, _active) = setup_seeded_api().await?;
     let http = reqwest::Client::new();
 
-    let dashboard = get_json(
+    let overview = get_json(
         &http,
-        format!("{base_url}/borrowers/by-script?script_pubkey=52ac"),
+        format!("{base_url}/borrowers/overview?script_pubkey=52ac"),
     )
     .await?;
 
-    let overview = &dashboard["overview"];
     assert_eq!(overview["active_loans"], 1);
     assert_eq!(overview["pending_offers"], 1);
     assert_eq!(
@@ -643,7 +642,36 @@ async fn borrower_dashboard_returns_overview_and_filtered_offers() -> anyhow::Re
     assert_eq!(overview["borrowings"].as_array().map_or(0, Vec::len), 1);
     assert_eq!(overview["borrowings"][0]["amount"], "1000");
 
-    let offers = &dashboard["offers"];
+    let unknown_wallet = get_json(
+        &http,
+        format!("{base_url}/borrowers/overview?script_pubkey=dead"),
+    )
+    .await?;
+    assert_eq!(unknown_wallet["active_loans"], 0);
+    assert_eq!(unknown_wallet["pending_offers"], 0);
+    assert_eq!(
+        unknown_wallet["collateral_locked"]
+            .as_array()
+            .map_or(0, Vec::len),
+        0
+    );
+
+    server_handle.abort();
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn borrower_offers_returns_paginated_list_for_script() -> anyhow::Result<()> {
+    let (base_url, server_handle, pending_offer, active_offer) = setup_seeded_api().await?;
+    let http = reqwest::Client::new();
+
+    let offers = get_json(
+        &http,
+        format!("{base_url}/borrowers/offers?script_pubkey=52ac"),
+    )
+    .await?;
+
     assert_eq!(offers["total"], 2);
     assert_eq!(offers["limit"], 50);
     assert_eq!(offers["offset"], 0);
@@ -662,31 +690,36 @@ async fn borrower_dashboard_returns_overview_and_filtered_offers() -> anyhow::Re
 
     let pending_only = get_json(
         &http,
-        format!("{base_url}/borrowers/by-script?script_pubkey=52ac&status=pending"),
+        format!("{base_url}/borrowers/offers?script_pubkey=52ac&status=pending"),
     )
     .await?;
-    assert_eq!(pending_only["offers"]["total"], 1);
-    assert_eq!(
-        pending_only["offers"]["items"][0]["id"],
-        pending_offer.to_string()
-    );
-    assert_eq!(pending_only["overview"]["pending_offers"], 1);
-    assert_eq!(pending_only["overview"]["active_loans"], 1);
+    assert_eq!(pending_only["total"], 1);
+    assert_eq!(pending_only["items"][0]["id"], pending_offer.to_string());
 
     let unknown_wallet = get_json(
         &http,
-        format!("{base_url}/borrowers/by-script?script_pubkey=dead"),
+        format!("{base_url}/borrowers/offers?script_pubkey=dead"),
     )
     .await?;
-    assert_eq!(unknown_wallet["overview"]["active_loans"], 0);
-    assert_eq!(unknown_wallet["overview"]["pending_offers"], 0);
-    assert_eq!(
-        unknown_wallet["overview"]["collateral_locked"]
-            .as_array()
-            .map_or(0, Vec::len),
-        0
-    );
-    assert_eq!(unknown_wallet["offers"]["total"], 0);
+    assert_eq!(unknown_wallet["total"], 0);
+
+    server_handle.abort();
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn borrower_overview_is_not_filtered_by_offer_list_params() -> anyhow::Result<()> {
+    let (base_url, server_handle, _pending, _active) = setup_seeded_api().await?;
+    let http = reqwest::Client::new();
+
+    let overview = get_json(
+        &http,
+        format!("{base_url}/borrowers/overview?script_pubkey=52ac&status=pending"),
+    )
+    .await?;
+    assert_eq!(overview["pending_offers"], 1);
+    assert_eq!(overview["active_loans"], 1);
 
     server_handle.abort();
     Ok(())


### PR DESCRIPTION
In this PR, the following was implemented:
- Tracking of the Borrower Principal UTXO after offer acceptance
- Splitting the `/borrowers/by-script` endpoint into `/borrowers/overview` and `/borrowers/offers`
- Added new endpoints `/lenders/overview` and `/lenders/offers`
- Information about offer participants and the borrower principal UTXO (if it exists) was added to all endpoints that return a list of offers