### PR TITLE
Feat/indexer api refactoring

### DIFF
--- a/crates/indexer/src/api/borrowers/db.rs
+++ b/crates/indexer/src/api/borrowers/db.rs
@@ -1,13 +1,12 @@
 use sqlx::{PgPool, Postgres, QueryBuilder};
 
 use crate::api::OfferListQuery;
-use crate::api::offers::db::{
-    apply_offer_list_filters, enrich_offer_list_items, push_offer_list_order_by,
-};
-use crate::api::offers::dto::{OfferListItemShort, OfferListResponse};
-use crate::api::participants::push_latest_participant_offers_scope;
+use crate::api::offers::dto::OfferListResponse;
+use crate::api::offers::list_query::fetch_participant_offers_list;
+use crate::api::query::{attach_latest_participant_offers_scope, attach_status_any};
 use crate::api::utils::{format_hex, format_satoshis};
-use crate::models::{OfferModelShort, OfferStatus, ParticipantType};
+
+use crate::models::{OfferStatus, ParticipantType};
 
 use super::dto::{AssetAmount, BorrowerOverview};
 
@@ -50,14 +49,13 @@ pub async fn fetch_overview(
         WHERE 1=1
         "#,
     );
-    push_latest_participant_offers_scope(
+    attach_latest_participant_offers_scope(
         &mut collateral_builder,
         ParticipantType::Borrower,
         script_pubkey,
     );
-    collateral_builder.push(" AND current_status = ANY(");
-    collateral_builder.push_bind(OPEN_BORROWER_STATUSES);
-    collateral_builder.push(") GROUP BY collateral_asset_id");
+    attach_status_any(&mut collateral_builder, &OPEN_BORROWER_STATUSES);
+    collateral_builder.push(" GROUP BY collateral_asset_id");
 
     let collateral_rows = collateral_builder
         .build_query_as::<AssetSumRow>()
@@ -71,14 +69,13 @@ pub async fn fetch_overview(
         WHERE 1=1
         "#,
     );
-    push_latest_participant_offers_scope(
+    attach_latest_participant_offers_scope(
         &mut borrowings_builder,
         ParticipantType::Borrower,
         script_pubkey,
     );
-    borrowings_builder.push(" AND current_status = ANY(");
-    borrowings_builder.push_bind(OPEN_BORROWER_STATUSES);
-    borrowings_builder.push(") GROUP BY principal_asset_id");
+    attach_status_any(&mut borrowings_builder, &OPEN_BORROWER_STATUSES);
+    borrowings_builder.push(" GROUP BY principal_asset_id");
 
     let borrowings_rows = borrowings_builder
         .build_query_as::<AssetSumRow>()
@@ -102,7 +99,7 @@ pub async fn fetch_overview(
         WHERE 1=1
         "#,
     );
-    push_latest_participant_offers_scope(
+    attach_latest_participant_offers_scope(
         &mut counts_builder,
         ParticipantType::Borrower,
         script_pubkey,
@@ -126,62 +123,5 @@ pub async fn fetch_offer_list(
     script_pubkey: &[u8],
     query: &OfferListQuery,
 ) -> Result<OfferListResponse, sqlx::Error> {
-    let limit = query.effective_limit();
-    let offset = query.effective_offset();
-
-    let mut count_builder: QueryBuilder<Postgres> =
-        QueryBuilder::new("SELECT COUNT(*)::BIGINT FROM offers WHERE 1=1");
-    push_latest_participant_offers_scope(
-        &mut count_builder,
-        ParticipantType::Borrower,
-        script_pubkey,
-    );
-    apply_offer_list_filters(&mut count_builder, query);
-    let total: i64 = count_builder.build_query_scalar().fetch_one(db).await?;
-
-    let mut query_builder: QueryBuilder<Postgres> = QueryBuilder::new(
-        r#"
-        SELECT
-            id,
-            issuance_factory_id,
-            current_status,
-            collateral_asset_id,
-            principal_asset_id,
-            collateral_amount,
-            principal_amount,
-            interest_rate,
-            loan_expiration_time,
-            created_at_height,
-            created_at_txid
-        FROM offers
-        WHERE 1=1
-        "#,
-    );
-    push_latest_participant_offers_scope(
-        &mut query_builder,
-        ParticipantType::Borrower,
-        script_pubkey,
-    );
-    apply_offer_list_filters(&mut query_builder, query);
-    push_offer_list_order_by(&mut query_builder, query);
-    query_builder.push(" LIMIT ");
-    query_builder.push_bind(limit as i64);
-    query_builder.push(" OFFSET ");
-    query_builder.push_bind(offset as i64);
-
-    let rows = query_builder
-        .build_query_as::<OfferModelShort>()
-        .fetch_all(db)
-        .await?;
-
-    let mut items: Vec<OfferListItemShort> =
-        rows.into_iter().map(OfferListItemShort::from).collect();
-    enrich_offer_list_items(db, &mut items).await?;
-
-    Ok(OfferListResponse {
-        items,
-        total: total as u64,
-        limit,
-        offset,
-    })
+    fetch_participant_offers_list(db, query, ParticipantType::Borrower, script_pubkey).await
 }

--- a/crates/indexer/src/api/borrowers/db.rs
+++ b/crates/indexer/src/api/borrowers/db.rs
@@ -1,36 +1,21 @@
 use sqlx::{PgPool, Postgres, QueryBuilder};
 
 use crate::api::OfferListQuery;
+use crate::api::db::{AssetSumRow, asset_amounts_from_rows};
 use crate::api::offers::dto::OfferListResponse;
 use crate::api::offers::list_query::fetch_participant_offers_list;
 use crate::api::query::{attach_latest_participant_offers_scope, attach_status_any};
-use crate::api::utils::{format_hex, format_satoshis};
 
 use crate::models::{OfferStatus, ParticipantType};
 
-use super::dto::{AssetAmount, BorrowerOverview};
+use super::dto::BorrowerOverview;
 
 const OPEN_BORROWER_STATUSES: [OfferStatus; 2] = [OfferStatus::Pending, OfferStatus::Active];
-
-#[derive(sqlx::FromRow)]
-struct AssetSumRow {
-    asset_id: Vec<u8>,
-    amount: i64,
-}
 
 #[derive(sqlx::FromRow)]
 struct BorrowerCountsRow {
     active_loans: i64,
     pending_offers: i64,
-}
-
-fn asset_amounts_from_rows(rows: Vec<AssetSumRow>) -> Vec<AssetAmount> {
-    rows.into_iter()
-        .map(|row| AssetAmount {
-            asset: format_hex(row.asset_id),
-            amount: format_satoshis(row.amount),
-        })
-        .collect()
 }
 
 #[tracing::instrument(

--- a/crates/indexer/src/api/borrowers/dto.rs
+++ b/crates/indexer/src/api/borrowers/dto.rs
@@ -1,13 +1,7 @@
 use serde::Serialize;
 use utoipa::ToSchema;
 
-#[derive(Serialize, ToSchema)]
-pub struct AssetAmount {
-    pub asset: String,
-    /// Amount in satoshis (decimal string).
-    #[schema(example = "1000")]
-    pub amount: String,
-}
+use crate::api::dto::AssetAmount;
 
 #[derive(Serialize, ToSchema)]
 pub struct BorrowerOverview {

--- a/crates/indexer/src/api/db/asset_sums.rs
+++ b/crates/indexer/src/api/db/asset_sums.rs
@@ -1,0 +1,17 @@
+use crate::api::dto::AssetAmount;
+use crate::api::utils::{format_hex, format_satoshis};
+
+#[derive(sqlx::FromRow)]
+pub(crate) struct AssetSumRow {
+    pub asset_id: Vec<u8>,
+    pub amount: i64,
+}
+
+pub(crate) fn asset_amounts_from_rows(rows: Vec<AssetSumRow>) -> Vec<AssetAmount> {
+    rows.into_iter()
+        .map(|row| AssetAmount {
+            asset: format_hex(row.asset_id),
+            amount: format_satoshis(row.amount),
+        })
+        .collect()
+}

--- a/crates/indexer/src/api/db/mod.rs
+++ b/crates/indexer/src/api/db/mod.rs
@@ -1,0 +1,3 @@
+mod asset_sums;
+
+pub(crate) use asset_sums::{AssetSumRow, asset_amounts_from_rows};

--- a/crates/indexer/src/api/dto/asset_amount.rs
+++ b/crates/indexer/src/api/dto/asset_amount.rs
@@ -1,0 +1,10 @@
+use serde::Serialize;
+use utoipa::ToSchema;
+
+#[derive(Serialize, ToSchema)]
+pub struct AssetAmount {
+    pub asset: String,
+    /// Amount in satoshis (decimal string).
+    #[schema(example = "1000")]
+    pub amount: String,
+}

--- a/crates/indexer/src/api/dto/mod.rs
+++ b/crates/indexer/src/api/dto/mod.rs
@@ -1,0 +1,3 @@
+mod asset_amount;
+
+pub use asset_amount::AssetAmount;

--- a/crates/indexer/src/api/lenders/db.rs
+++ b/crates/indexer/src/api/lenders/db.rs
@@ -2,14 +2,12 @@ use sqlx::{PgPool, Postgres, QueryBuilder};
 
 use crate::api::OfferListQuery;
 use crate::api::borrowers::dto::AssetAmount;
-use crate::api::offers::db::{
-    apply_offer_list_filters, enrich_offer_list_items, push_offer_list_order_by,
-};
-use crate::api::offers::dto::{OfferListItemShort, OfferListResponse};
-use crate::api::participants::push_latest_participant_offers_scope;
+use crate::api::offers::dto::OfferListResponse;
+use crate::api::offers::list_query::fetch_participant_offers_list;
+use crate::api::query::attach_latest_participant_offers_scope;
 use crate::api::utils::{format_hex, format_satoshis};
 
-use crate::models::{OfferModelShort, OfferStatus, ParticipantType};
+use crate::models::{OfferStatus, ParticipantType};
 
 use super::dto::LenderOverview;
 
@@ -51,7 +49,7 @@ pub async fn fetch_overview(
     );
     supplied_builder.push_bind(OfferStatus::Active);
     supplied_builder.push(" AND 1=1");
-    push_latest_participant_offers_scope(
+    attach_latest_participant_offers_scope(
         &mut supplied_builder,
         ParticipantType::Lender,
         script_pubkey,
@@ -73,7 +71,7 @@ pub async fn fetch_overview(
     );
     interest_builder.push_bind(OfferStatus::Active);
     interest_builder.push(" AND 1=1");
-    push_latest_participant_offers_scope(
+    attach_latest_participant_offers_scope(
         &mut interest_builder,
         ParticipantType::Lender,
         script_pubkey,
@@ -102,7 +100,7 @@ pub async fn fetch_overview(
         WHERE 1=1
         "#,
     );
-    push_latest_participant_offers_scope(
+    attach_latest_participant_offers_scope(
         &mut counts_builder,
         ParticipantType::Lender,
         script_pubkey,
@@ -126,62 +124,5 @@ pub async fn fetch_offer_list(
     script_pubkey: &[u8],
     query: &OfferListQuery,
 ) -> Result<OfferListResponse, sqlx::Error> {
-    let limit = query.effective_limit();
-    let offset = query.effective_offset();
-
-    let mut count_builder: QueryBuilder<Postgres> =
-        QueryBuilder::new("SELECT COUNT(*)::BIGINT FROM offers WHERE 1=1");
-    push_latest_participant_offers_scope(
-        &mut count_builder,
-        ParticipantType::Lender,
-        script_pubkey,
-    );
-    apply_offer_list_filters(&mut count_builder, query);
-    let total: i64 = count_builder.build_query_scalar().fetch_one(db).await?;
-
-    let mut query_builder: QueryBuilder<Postgres> = QueryBuilder::new(
-        r#"
-        SELECT
-            id,
-            issuance_factory_id,
-            current_status,
-            collateral_asset_id,
-            principal_asset_id,
-            collateral_amount,
-            principal_amount,
-            interest_rate,
-            loan_expiration_time,
-            created_at_height,
-            created_at_txid
-        FROM offers
-        WHERE 1=1
-        "#,
-    );
-    push_latest_participant_offers_scope(
-        &mut query_builder,
-        ParticipantType::Lender,
-        script_pubkey,
-    );
-    apply_offer_list_filters(&mut query_builder, query);
-    push_offer_list_order_by(&mut query_builder, query);
-    query_builder.push(" LIMIT ");
-    query_builder.push_bind(limit as i64);
-    query_builder.push(" OFFSET ");
-    query_builder.push_bind(offset as i64);
-
-    let rows = query_builder
-        .build_query_as::<OfferModelShort>()
-        .fetch_all(db)
-        .await?;
-
-    let mut items: Vec<OfferListItemShort> =
-        rows.into_iter().map(OfferListItemShort::from).collect();
-    enrich_offer_list_items(db, &mut items).await?;
-
-    Ok(OfferListResponse {
-        items,
-        total: total as u64,
-        limit,
-        offset,
-    })
+    fetch_participant_offers_list(db, query, ParticipantType::Lender, script_pubkey).await
 }

--- a/crates/indexer/src/api/lenders/db.rs
+++ b/crates/indexer/src/api/lenders/db.rs
@@ -1,35 +1,19 @@
 use sqlx::{PgPool, Postgres, QueryBuilder};
 
 use crate::api::OfferListQuery;
-use crate::api::borrowers::dto::AssetAmount;
+use crate::api::db::{AssetSumRow, asset_amounts_from_rows};
 use crate::api::offers::dto::OfferListResponse;
 use crate::api::offers::list_query::fetch_participant_offers_list;
 use crate::api::query::attach_latest_participant_offers_scope;
-use crate::api::utils::{format_hex, format_satoshis};
 
 use crate::models::{OfferStatus, ParticipantType};
 
 use super::dto::LenderOverview;
 
 #[derive(sqlx::FromRow)]
-struct AssetSumRow {
-    asset_id: Vec<u8>,
-    amount: i64,
-}
-
-#[derive(sqlx::FromRow)]
 struct LenderCountsRow {
     active_loans: i64,
     to_be_claimed: i64,
-}
-
-fn asset_amounts_from_rows(rows: Vec<AssetSumRow>) -> Vec<AssetAmount> {
-    rows.into_iter()
-        .map(|row| AssetAmount {
-            asset: format_hex(row.asset_id),
-            amount: format_satoshis(row.amount),
-        })
-        .collect()
 }
 
 #[tracing::instrument(

--- a/crates/indexer/src/api/lenders/dto.rs
+++ b/crates/indexer/src/api/lenders/dto.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 use utoipa::ToSchema;
 
-use crate::api::borrowers::dto::AssetAmount;
+use crate::api::dto::AssetAmount;
 
 #[derive(Serialize, ToSchema)]
 pub struct LenderOverview {

--- a/crates/indexer/src/api/mod.rs
+++ b/crates/indexer/src/api/mod.rs
@@ -1,4 +1,6 @@
 mod borrowers;
+mod db;
+mod dto;
 mod error;
 mod factories;
 mod lenders;
@@ -10,6 +12,7 @@ pub mod server;
 mod state;
 pub mod utils;
 
+pub use dto::AssetAmount;
 pub use error::*;
 pub use openapi::ApiDoc;
 pub use params::*;

--- a/crates/indexer/src/api/mod.rs
+++ b/crates/indexer/src/api/mod.rs
@@ -5,7 +5,7 @@ mod lenders;
 mod offers;
 mod openapi;
 mod params;
-mod participants;
+mod query;
 pub mod server;
 mod state;
 pub mod utils;

--- a/crates/indexer/src/api/offers/db.rs
+++ b/crates/indexer/src/api/offers/db.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 use simplex::simplicityhl::elements::hex::ToHex;
 
 use crate::api::OfferListQuery;
-use crate::api::utils::{format_hex, format_satoshis};
+use crate::api::db::{AssetSumRow, asset_amounts_from_rows};
 use crate::models::{
     OfferModel, OfferParticipantModel, OfferStatus, OfferUtxoModel, ParticipantType, UtxoType,
 };
@@ -14,23 +14,6 @@ use super::dto::{
     ParticipantDto,
 };
 use super::list_query::fetch_all_offers_list;
-
-use crate::api::borrowers::dto::AssetAmount;
-
-#[derive(sqlx::FromRow)]
-struct AssetSumRow {
-    asset_id: Vec<u8>,
-    amount: i64,
-}
-
-fn asset_amounts_from_rows(rows: Vec<AssetSumRow>) -> Vec<AssetAmount> {
-    rows.into_iter()
-        .map(|row| AssetAmount {
-            asset: format_hex(row.asset_id),
-            amount: format_satoshis(row.amount),
-        })
-        .collect()
-}
 
 const OPEN_COLLATERAL_STATUSES: [OfferStatus; 2] = [OfferStatus::Pending, OfferStatus::Active];
 

--- a/crates/indexer/src/api/offers/db.rs
+++ b/crates/indexer/src/api/offers/db.rs
@@ -1,19 +1,19 @@
-use simplex::simplicityhl::elements::hex::ToHex;
-use sqlx::{PgPool, Postgres, QueryBuilder};
-use std::collections::HashMap;
+use sqlx::PgPool;
 use uuid::Uuid;
 
-use crate::api::utils::{format_hex, format_satoshis, parse_filter_hex};
-use crate::api::{OfferListQuery, SortDir};
+use simplex::simplicityhl::elements::hex::ToHex;
+
+use crate::api::OfferListQuery;
+use crate::api::utils::{format_hex, format_satoshis};
 use crate::models::{
-    OfferModel, OfferModelShort, OfferParticipantModel, OfferStatus, OfferUtxoModel,
-    ParticipantType, UtxoType,
+    OfferModel, OfferParticipantModel, OfferStatus, OfferUtxoModel, ParticipantType, UtxoType,
 };
 
 use super::dto::{
-    OfferDetailsResponse, OfferListItemFull, OfferListItemShort, OfferListResponse, OfferUtxoDto,
-    OfferUtxoOutpointShort, OffersOverview, ParticipantDto, ParticipantShort,
+    OfferDetailsResponse, OfferListItemFull, OfferListResponse, OfferUtxoDto, OffersOverview,
+    ParticipantDto,
 };
+use super::list_query::fetch_all_offers_list;
 
 use crate::api::borrowers::dto::AssetAmount;
 
@@ -33,93 +33,6 @@ fn asset_amounts_from_rows(rows: Vec<AssetSumRow>) -> Vec<AssetAmount> {
 }
 
 const OPEN_COLLATERAL_STATUSES: [OfferStatus; 2] = [OfferStatus::Pending, OfferStatus::Active];
-
-#[derive(sqlx::FromRow)]
-struct ParticipantListRow {
-    offer_id: Uuid,
-    participant_type: ParticipantType,
-    script_pubkey: Vec<u8>,
-}
-
-#[derive(sqlx::FromRow)]
-struct BorrowerPrincipalListRow {
-    offer_id: Uuid,
-    txid: Vec<u8>,
-    vout: i32,
-}
-
-pub(crate) async fn enrich_offer_list_items(
-    db: &PgPool,
-    items: &mut [OfferListItemShort],
-) -> Result<(), sqlx::Error> {
-    if items.is_empty() {
-        return Ok(());
-    }
-
-    let offer_ids: Vec<Uuid> = items.iter().map(|item| item.id).collect();
-
-    let participant_rows = sqlx::query_as::<_, ParticipantListRow>(
-        r#"
-        SELECT DISTINCT ON (offer_id, participant_type)
-            offer_id,
-            participant_type,
-            script_pubkey
-        FROM offer_participants
-        WHERE offer_id = ANY($1)
-        ORDER BY offer_id, participant_type, created_at_height DESC
-        "#,
-    )
-    .bind(&offer_ids)
-    .fetch_all(db)
-    .await?;
-
-    let principal_rows = sqlx::query_as::<_, BorrowerPrincipalListRow>(
-        r#"
-        SELECT offer_id, txid, vout
-        FROM offer_utxos
-        WHERE spent_txid IS NULL
-          AND utxo_type = $1
-          AND offer_id = ANY($2)
-        "#,
-    )
-    .bind(UtxoType::BorrowerPrincipal)
-    .bind(&offer_ids)
-    .fetch_all(db)
-    .await?;
-
-    let mut participants_by_offer: HashMap<Uuid, Vec<ParticipantShort>> = HashMap::new();
-    for row in participant_rows {
-        participants_by_offer
-            .entry(row.offer_id)
-            .or_default()
-            .push(ParticipantShort {
-                participant_type: row.participant_type,
-                script_pubkey: row.script_pubkey.to_hex(),
-            });
-    }
-
-    for participants in participants_by_offer.values_mut() {
-        participants.sort_by_key(|participant| participant.participant_type);
-    }
-
-    let mut principal_by_offer: HashMap<Uuid, OfferUtxoOutpointShort> = HashMap::new();
-    for row in principal_rows {
-        principal_by_offer.insert(
-            row.offer_id,
-            OfferUtxoOutpointShort {
-                txid: format_hex(row.txid),
-                vout: row.vout as u32,
-            },
-        );
-    }
-
-    for item in items.iter_mut() {
-        item.participants = participants_by_offer.remove(&item.id).unwrap_or_default();
-        item.borrower_principal_utxo = principal_by_offer.remove(&item.id);
-    }
-
-    Ok(())
-}
 
 #[tracing::instrument(name = "Fetching offers overview from DB", skip(db))]
 pub async fn fetch_overview(db: &PgPool) -> Result<OffersOverview, sqlx::Error> {
@@ -162,58 +75,6 @@ pub async fn fetch_overview(db: &PgPool) -> Result<OffersOverview, sqlx::Error> 
     })
 }
 
-pub(crate) fn apply_offer_list_filters<'a>(
-    query_builder: &mut QueryBuilder<'a, Postgres>,
-    query: &'a OfferListQuery,
-) {
-    if !query.status.is_empty() {
-        query_builder.push(" AND current_status = ANY(");
-        query_builder.push_bind(query.status.clone());
-        query_builder.push(")");
-    }
-
-    if let Some(factory_id) = query.factory_id {
-        query_builder.push(" AND issuance_factory_id = ");
-        query_builder.push_bind(factory_id);
-    }
-
-    if let Some(collateral_asset_hex) = &query.collateral_asset {
-        if let Some(bin) = parse_filter_hex(collateral_asset_hex) {
-            query_builder.push(" AND collateral_asset_id = ");
-            query_builder.push_bind(bin);
-        } else {
-            tracing::warn!(
-                collateral_asset_hex,
-                "Failed to decode collateral_asset hex filter"
-            );
-        }
-    }
-
-    if let Some(principal_asset_hex) = &query.principal_asset {
-        if let Some(bin) = parse_filter_hex(principal_asset_hex) {
-            query_builder.push(" AND principal_asset_id = ");
-            query_builder.push_bind(bin);
-        } else {
-            tracing::warn!(
-                principal_asset_hex,
-                "Failed to decode principal_asset hex filter"
-            );
-        }
-    }
-}
-
-pub(crate) fn push_offer_list_order_by(
-    query_builder: &mut QueryBuilder<Postgres>,
-    query: &OfferListQuery,
-) {
-    query_builder.push(" ORDER BY ");
-    query_builder.push(query.sort_by.sql_column());
-    query_builder.push(match query.sort_dir {
-        SortDir::Asc => " ASC",
-        SortDir::Desc => " DESC",
-    });
-}
-
 #[tracing::instrument(
     name = "Fetching offers list from DB",
     skip(db, query),
@@ -232,57 +93,7 @@ pub async fn fetch_list(
     db: &PgPool,
     query: OfferListQuery,
 ) -> Result<OfferListResponse, sqlx::Error> {
-    let limit = query.effective_limit();
-    let offset = query.effective_offset();
-
-    let mut count_builder: QueryBuilder<Postgres> =
-        QueryBuilder::new("SELECT COUNT(*)::BIGINT FROM offers WHERE 1=1");
-    apply_offer_list_filters(&mut count_builder, &query);
-    let total: i64 = count_builder.build_query_scalar().fetch_one(db).await?;
-
-    let mut query_builder: QueryBuilder<Postgres> = QueryBuilder::new(
-        r#"
-            SELECT
-                id,
-                issuance_factory_id,
-                current_status,
-                collateral_asset_id,
-                principal_asset_id,
-                collateral_amount,
-                principal_amount,
-                interest_rate,
-                loan_expiration_time,
-                created_at_height,
-                created_at_txid
-            FROM offers
-            WHERE 1=1
-        "#,
-    );
-
-    apply_offer_list_filters(&mut query_builder, &query);
-    push_offer_list_order_by(&mut query_builder, &query);
-
-    query_builder.push(" LIMIT ");
-    query_builder.push_bind(limit as i64);
-
-    query_builder.push(" OFFSET ");
-    query_builder.push_bind(offset as i64);
-
-    let rows = query_builder
-        .build_query_as::<OfferModelShort>()
-        .fetch_all(db)
-        .await?;
-
-    let mut items: Vec<OfferListItemShort> =
-        rows.into_iter().map(OfferListItemShort::from).collect();
-    enrich_offer_list_items(db, &mut items).await?;
-
-    Ok(OfferListResponse {
-        items,
-        total: total as u64,
-        limit,
-        offset,
-    })
+    fetch_all_offers_list(db, &query).await
 }
 
 async fn fetch_full_info_by_id(

--- a/crates/indexer/src/api/offers/dto.rs
+++ b/crates/indexer/src/api/offers/dto.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 
 use simplex::simplicityhl::elements::hex::ToHex;
 
-use crate::api::borrowers::dto::AssetAmount;
+use crate::api::dto::AssetAmount;
 use crate::api::utils::{format_hex, format_satoshis};
 use crate::models::{
     OfferModel, OfferModelShort, OfferParticipantModel, OfferStatus, OfferUtxoModel,

--- a/crates/indexer/src/api/offers/list_query.rs
+++ b/crates/indexer/src/api/offers/list_query.rs
@@ -1,0 +1,198 @@
+use std::collections::HashMap;
+
+use sqlx::{PgPool, Postgres, QueryBuilder};
+use uuid::Uuid;
+
+use simplex::simplicityhl::elements::hex::ToHex;
+
+use crate::api::OfferListQuery;
+use crate::api::query::{
+    attach_latest_participant_offers_scope, attach_offer_list_filters, attach_offer_list_order_by,
+    attach_paginate,
+};
+use crate::api::utils::format_hex;
+
+use crate::models::{OfferModelShort, ParticipantType, UtxoType};
+
+use super::dto::{OfferListItemShort, OfferListResponse, OfferUtxoOutpointShort, ParticipantShort};
+
+const OFFERS_SHORT_LIST_SELECT: &str = r#"
+    SELECT
+        id,
+        issuance_factory_id,
+        current_status,
+        collateral_asset_id,
+        principal_asset_id,
+        collateral_amount,
+        principal_amount,
+        interest_rate,
+        loan_expiration_time,
+        created_at_height,
+        created_at_txid
+    FROM offers
+    WHERE 1=1
+"#;
+
+pub async fn fetch_all_offers_list(
+    db: &PgPool,
+    query: &OfferListQuery,
+) -> Result<OfferListResponse, sqlx::Error> {
+    fetch_paginated_short_offers(db, query, None).await
+}
+
+pub async fn fetch_participant_offers_list(
+    db: &PgPool,
+    query: &OfferListQuery,
+    participant_type: ParticipantType,
+    script_pubkey: &[u8],
+) -> Result<OfferListResponse, sqlx::Error> {
+    fetch_paginated_short_offers(db, query, Some((participant_type, script_pubkey))).await
+}
+
+#[tracing::instrument(
+    name = "Fetching paginated short offers from DB",
+    skip(db, query, participant),
+    fields(
+        limit = %query.effective_limit(),
+        offset = %query.effective_offset(),
+        status = ?query.status,
+        collateral_asset = ?query.collateral_asset,
+        principal_asset = ?query.principal_asset,
+        factory_id = ?query.factory_id,
+        sort_by = ?query.sort_by,
+        sort_dir = ?query.sort_dir,
+        participant_role = ?participant.map(|(role, _)| role),
+    )
+)]
+async fn fetch_paginated_short_offers(
+    db: &PgPool,
+    query: &OfferListQuery,
+    participant: Option<(ParticipantType, &[u8])>,
+) -> Result<OfferListResponse, sqlx::Error> {
+    let limit = query.effective_limit();
+    let offset = query.effective_offset();
+
+    let mut count_builder: QueryBuilder<Postgres> =
+        QueryBuilder::new("SELECT COUNT(*)::BIGINT FROM offers WHERE 1=1");
+    attach_offer_list_where(&mut count_builder, query, participant);
+    let total: i64 = count_builder.build_query_scalar().fetch_one(db).await?;
+
+    let mut query_builder: QueryBuilder<Postgres> = QueryBuilder::new(OFFERS_SHORT_LIST_SELECT);
+    attach_offer_list_where(&mut query_builder, query, participant);
+    attach_offer_list_order_by(&mut query_builder, query);
+    attach_paginate(&mut query_builder, limit as i64, offset as i64);
+
+    let rows = query_builder
+        .build_query_as::<OfferModelShort>()
+        .fetch_all(db)
+        .await?;
+
+    let mut items: Vec<OfferListItemShort> =
+        rows.into_iter().map(OfferListItemShort::from).collect();
+    enrich_offer_list_items(db, &mut items).await?;
+
+    Ok(OfferListResponse {
+        items,
+        total: total as u64,
+        limit,
+        offset,
+    })
+}
+
+fn attach_offer_list_where<'a>(
+    query_builder: &mut QueryBuilder<'a, Postgres>,
+    query: &'a OfferListQuery,
+    participant: Option<(ParticipantType, &'a [u8])>,
+) {
+    if let Some((participant_type, script_pubkey)) = participant {
+        attach_latest_participant_offers_scope(query_builder, participant_type, script_pubkey);
+    }
+    attach_offer_list_filters(query_builder, query);
+}
+
+#[derive(sqlx::FromRow)]
+struct ParticipantListRow {
+    offer_id: Uuid,
+    participant_type: ParticipantType,
+    script_pubkey: Vec<u8>,
+}
+
+#[derive(sqlx::FromRow)]
+struct BorrowerPrincipalListRow {
+    offer_id: Uuid,
+    txid: Vec<u8>,
+    vout: i32,
+}
+
+async fn enrich_offer_list_items(
+    db: &PgPool,
+    items: &mut [OfferListItemShort],
+) -> Result<(), sqlx::Error> {
+    if items.is_empty() {
+        return Ok(());
+    }
+
+    let offer_ids: Vec<Uuid> = items.iter().map(|item| item.id).collect();
+
+    let participant_rows = sqlx::query_as::<_, ParticipantListRow>(
+        r#"
+        SELECT DISTINCT ON (offer_id, participant_type)
+            offer_id,
+            participant_type,
+            script_pubkey
+        FROM offer_participants
+        WHERE offer_id = ANY($1)
+        ORDER BY offer_id, participant_type, created_at_height DESC
+        "#,
+    )
+    .bind(&offer_ids)
+    .fetch_all(db)
+    .await?;
+
+    let principal_rows = sqlx::query_as::<_, BorrowerPrincipalListRow>(
+        r#"
+        SELECT offer_id, txid, vout
+        FROM offer_utxos
+        WHERE spent_txid IS NULL
+          AND utxo_type = $1
+          AND offer_id = ANY($2)
+        "#,
+    )
+    .bind(UtxoType::BorrowerPrincipal)
+    .bind(&offer_ids)
+    .fetch_all(db)
+    .await?;
+
+    let mut participants_by_offer: HashMap<Uuid, Vec<ParticipantShort>> = HashMap::new();
+    for row in participant_rows {
+        participants_by_offer
+            .entry(row.offer_id)
+            .or_default()
+            .push(ParticipantShort {
+                participant_type: row.participant_type,
+                script_pubkey: row.script_pubkey.to_hex(),
+            });
+    }
+
+    for participants in participants_by_offer.values_mut() {
+        participants.sort_by_key(|participant| participant.participant_type);
+    }
+
+    let mut principal_by_offer: HashMap<Uuid, OfferUtxoOutpointShort> = HashMap::new();
+    for row in principal_rows {
+        principal_by_offer.insert(
+            row.offer_id,
+            OfferUtxoOutpointShort {
+                txid: format_hex(row.txid),
+                vout: row.vout as u32,
+            },
+        );
+    }
+
+    for item in items.iter_mut() {
+        item.participants = participants_by_offer.remove(&item.id).unwrap_or_default();
+        item.borrower_principal_utxo = principal_by_offer.remove(&item.id);
+    }
+
+    Ok(())
+}

--- a/crates/indexer/src/api/offers/mod.rs
+++ b/crates/indexer/src/api/offers/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod db;
 pub(crate) mod dto;
 pub(crate) mod handlers;
+pub(crate) mod list_query;
 mod routes;
 
 pub use routes::routes;

--- a/crates/indexer/src/api/openapi/doc.rs
+++ b/crates/indexer/src/api/openapi/doc.rs
@@ -3,8 +3,9 @@ use utoipa::OpenApi;
 #[cfg(feature = "swagger-ui")]
 use utoipa_swagger_ui::SwaggerUi;
 
-use crate::api::borrowers::dto::{AssetAmount, BorrowerOverview};
+use crate::api::borrowers::dto::BorrowerOverview;
 use crate::api::borrowers::handlers as borrower_handlers;
+use crate::api::dto::AssetAmount;
 use crate::api::factories::dto::{
     FactoryAuthUtxoDto, FactoryDetailsResponse, FactoryProgramUtxoDto,
 };

--- a/crates/indexer/src/api/participants/mod.rs
+++ b/crates/indexer/src/api/participants/mod.rs
@@ -1,3 +1,0 @@
-mod scope;
-
-pub use scope::push_latest_participant_offers_scope;

--- a/crates/indexer/src/api/query/list.rs
+++ b/crates/indexer/src/api/query/list.rs
@@ -1,0 +1,22 @@
+use sqlx::{Postgres, QueryBuilder};
+
+use crate::api::{OfferListQuery, SortDir};
+
+pub fn attach_offer_list_order_by(
+    query_builder: &mut QueryBuilder<Postgres>,
+    query: &OfferListQuery,
+) {
+    query_builder.push(" ORDER BY ");
+    query_builder.push(query.sort_by.sql_column());
+    query_builder.push(match query.sort_dir {
+        SortDir::Asc => " ASC",
+        SortDir::Desc => " DESC",
+    });
+}
+
+pub fn attach_paginate(query_builder: &mut QueryBuilder<Postgres>, limit: i64, offset: i64) {
+    query_builder.push(" LIMIT ");
+    query_builder.push_bind(limit);
+    query_builder.push(" OFFSET ");
+    query_builder.push_bind(offset);
+}

--- a/crates/indexer/src/api/query/mod.rs
+++ b/crates/indexer/src/api/query/mod.rs
@@ -1,0 +1,7 @@
+mod list;
+mod offers;
+mod participants;
+
+pub use list::{attach_offer_list_order_by, attach_paginate};
+pub use offers::{attach_offer_list_filters, attach_status_any};
+pub use participants::attach_latest_participant_offers_scope;

--- a/crates/indexer/src/api/query/offers.rs
+++ b/crates/indexer/src/api/query/offers.rs
@@ -1,0 +1,55 @@
+use sqlx::{Postgres, QueryBuilder};
+
+use crate::api::OfferListQuery;
+use crate::api::utils::parse_filter_hex;
+use crate::models::OfferStatus;
+
+pub fn attach_status_any<'a>(
+    query_builder: &mut QueryBuilder<'a, Postgres>,
+    statuses: &'a [OfferStatus],
+) {
+    if statuses.is_empty() {
+        return;
+    }
+    query_builder.push(" AND current_status = ANY(");
+    query_builder.push_bind(statuses);
+    query_builder.push(")");
+}
+
+pub fn attach_offer_list_filters<'a>(
+    query_builder: &mut QueryBuilder<'a, Postgres>,
+    query: &'a OfferListQuery,
+) {
+    if !query.status.is_empty() {
+        attach_status_any(query_builder, &query.status);
+    }
+
+    if let Some(factory_id) = query.factory_id {
+        query_builder.push(" AND issuance_factory_id = ");
+        query_builder.push_bind(factory_id);
+    }
+
+    if let Some(collateral_asset_hex) = &query.collateral_asset {
+        if let Some(bin) = parse_filter_hex(collateral_asset_hex) {
+            query_builder.push(" AND collateral_asset_id = ");
+            query_builder.push_bind(bin);
+        } else {
+            tracing::warn!(
+                collateral_asset_hex,
+                "Failed to decode collateral_asset hex filter"
+            );
+        }
+    }
+
+    if let Some(principal_asset_hex) = &query.principal_asset {
+        if let Some(bin) = parse_filter_hex(principal_asset_hex) {
+            query_builder.push(" AND principal_asset_id = ");
+            query_builder.push_bind(bin);
+        } else {
+            tracing::warn!(
+                principal_asset_hex,
+                "Failed to decode principal_asset hex filter"
+            );
+        }
+    }
+}

--- a/crates/indexer/src/api/query/participants.rs
+++ b/crates/indexer/src/api/query/participants.rs
@@ -2,7 +2,7 @@ use sqlx::{Postgres, QueryBuilder};
 
 use crate::models::ParticipantType;
 
-pub fn push_latest_participant_offers_scope<'a>(
+pub fn attach_latest_participant_offers_scope<'a>(
     query_builder: &mut QueryBuilder<'a, Postgres>,
     participant_type: ParticipantType,
     script_pubkey: &'a [u8],


### PR DESCRIPTION
In this PR, refactoring was performed on the following points:
1. The core logic used to construct API requests was moved to a separate module
2. The core `AssetAmount` structures were moved to separate, API-shared modules