### PR TITLE
Add borrower principal utxo data to the offer details endpoint

### DIFF
--- a/crates/indexer/README.md
+++ b/crates/indexer/README.md
@@ -222,6 +222,7 @@ The following parameters are available for `GET /offers`, `GET /borrowers/offers
 
 **Offer details** (`GET /offers/{id}`) — full offer fields (short + NFT asset ids) plus:
 
+- `borrower_principal_utxo`: unspent `borrower_principal` UTXO outpoint (`txid`, `vout`), or omitted when none
 - `participants`: latest participant UTXO per role (`borrower`, `lender`)
 - `utxos`: current unspent offer UTXOs only (`spent_txid IS NULL`). Active offers may include both `active_offer` (Lending covenant) and `borrower_principal` (borrower principal AssetAuth locked until repayment).
 

--- a/crates/indexer/src/api/offers/db.rs
+++ b/crates/indexer/src/api/offers/db.rs
@@ -11,7 +11,7 @@ use crate::models::{
 
 use super::dto::{
     OfferDetailsResponse, OfferListItemFull, OfferListResponse, OfferUtxoDto, OffersOverview,
-    ParticipantDto,
+    ParticipantDto, borrower_principal_outpoint_from_utxos,
 };
 use super::list_query::fetch_all_offers_list;
 
@@ -185,6 +185,9 @@ pub async fn fetch_details_by_id(
         fetch_latest_participants(db, offer_id),
         fetch_unspent_utxos(db, offer_id),
     )?;
+
+    let mut info = info;
+    info.base.borrower_principal_utxo = borrower_principal_outpoint_from_utxos(&utxos);
 
     Ok(Some(OfferDetailsResponse {
         info,

--- a/crates/indexer/src/api/offers/dto.rs
+++ b/crates/indexer/src/api/offers/dto.rs
@@ -41,6 +41,18 @@ impl From<&OfferUtxoModel> for OfferUtxoOutpointShort {
     }
 }
 
+pub fn borrower_principal_outpoint_from_utxos(
+    utxos: &[OfferUtxoDto],
+) -> Option<OfferUtxoOutpointShort> {
+    utxos
+        .iter()
+        .find(|utxo| utxo.utxo_type == UtxoType::BorrowerPrincipal)
+        .map(|utxo| OfferUtxoOutpointShort {
+            txid: utxo.txid.clone(),
+            vout: utxo.vout,
+        })
+}
+
 #[derive(Serialize, ToSchema)]
 pub struct OfferListItemShort {
     pub id: Uuid,
@@ -376,6 +388,53 @@ mod tests {
         assert_eq!(dto.created_at_height, 123);
         assert_eq!(dto.spent_txid, Some("bbaa".to_string()));
         assert_eq!(dto.spent_at_height, Some(456));
+    }
+
+    #[test]
+    fn borrower_principal_outpoint_from_utxos_picks_borrower_principal_type() {
+        let offer_id = Uuid::new_v4();
+        let utxos = vec![
+            OfferUtxoDto {
+                offer_id,
+                txid: "aa".to_string(),
+                vout: 0,
+                utxo_type: UtxoType::ActiveOffer,
+                created_at_height: 1,
+                spent_txid: None,
+                spent_at_height: None,
+            },
+            OfferUtxoDto {
+                offer_id,
+                txid: "bb".to_string(),
+                vout: 1,
+                utxo_type: UtxoType::BorrowerPrincipal,
+                created_at_height: 2,
+                spent_txid: None,
+                spent_at_height: None,
+            },
+        ];
+
+        let outpoint = super::borrower_principal_outpoint_from_utxos(&utxos)
+            .expect("should find borrower principal");
+
+        assert_eq!(outpoint.txid, "bb");
+        assert_eq!(outpoint.vout, 1);
+    }
+
+    #[test]
+    fn borrower_principal_outpoint_from_utxos_returns_none_when_missing() {
+        let offer_id = Uuid::new_v4();
+        let utxos = vec![OfferUtxoDto {
+            offer_id,
+            txid: "aa".to_string(),
+            vout: 0,
+            utxo_type: UtxoType::ActiveOffer,
+            created_at_height: 1,
+            spent_txid: None,
+            spent_at_height: None,
+        }];
+
+        assert!(super::borrower_principal_outpoint_from_utxos(&utxos).is_none());
     }
 
     #[test]

--- a/crates/indexer/src/api/openapi/schemas.rs
+++ b/crates/indexer/src/api/openapi/schemas.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-use crate::api::offers::dto::{OfferUtxoDto, ParticipantDto};
+use crate::api::offers::dto::{OfferUtxoDto, OfferUtxoOutpointShort, ParticipantDto};
 use crate::models::OfferStatus;
 
 #[derive(Serialize, ToSchema)]
@@ -41,6 +41,8 @@ pub struct OfferDetailsResponseSchema {
     pub borrower_nft_asset: String,
     pub lender_nft_asset: String,
     pub protocol_fee_keeper_asset: String,
+    #[schema(value_type = Option<OfferUtxoOutpointShort>)]
+    pub borrower_principal_utxo: Option<OfferUtxoOutpointShort>,
     pub participants: Vec<ParticipantDto>,
     pub utxos: Vec<OfferUtxoDto>,
 }

--- a/crates/indexer/tests/api_integration.rs
+++ b/crates/indexer/tests/api_integration.rs
@@ -619,8 +619,16 @@ struct ExpectedOfferDetailsDto {
     borrower_nft_asset: String,
     lender_nft_asset: String,
     protocol_fee_keeper_asset: String,
+    borrower_principal_utxo: Option<ExpectedOfferUtxoOutpointShort>,
     utxos: Vec<ExpectedOfferUtxoDto>,
     participants: Vec<ExpectedParticipantDto>,
+}
+
+#[derive(serde::Deserialize, Debug)]
+#[allow(dead_code)]
+struct ExpectedOfferUtxoOutpointShort {
+    txid: String,
+    vout: u32,
 }
 
 #[derive(serde::Deserialize, Debug)]
@@ -692,6 +700,7 @@ async fn offer_details_full_dto_shape() -> anyhow::Result<()> {
     assert_eq!(dto.utxos.len(), 1);
     assert_eq!(dto.utxos[0].utxo_type, "active_offer");
     assert!(dto.utxos[0].spent_txid.is_none());
+    assert!(dto.borrower_principal_utxo.is_none());
     assert_eq!(dto.participants.len(), 2);
     assert!(
         dto.participants
@@ -726,6 +735,11 @@ async fn active_offer_details_includes_borrower_principal_utxo() -> anyhow::Resu
     assert!(utxo_types.contains(&"active_offer"));
     assert!(utxo_types.contains(&"borrower_principal"));
     assert!(dto.utxos.iter().all(|u| u.spent_txid.is_none()));
+
+    let principal = dto
+        .borrower_principal_utxo
+        .expect("active offer should include borrower_principal_utxo");
+    assert_eq!(principal.vout, 1);
 
     server_handle.abort();
     Ok(())


### PR DESCRIPTION
In the `/offers/{id}` endpoint, which returns offer details, information about the borrower's principal UTXO was not included in the offer info, just like in the other endpoints.

This PR fixes the issue with recording information about the borrower's principal UTXO.