### PR TITLE
Harden render-web-config.sh: require upstream env vars + validate nginx config

### DIFF
--- a/deployment/scripts/render-web-config.sh
+++ b/deployment/scripts/render-web-config.sh
@@ -1,8 +1,19 @@
 #!/bin/sh
 set -eu
 
+# These upstreams are substituted into default.conf.template below. If either
+# is unset, envsubst renders a scheme-less proxy_pass (e.g. "proxy_pass /...;")
+# and nginx aborts at startup with a cryptic "invalid URL prefix". Require them
+# explicitly so the failure names the missing variable instead.
+: "${WEB_ESPLORA_API_UPSTREAM:?WEB_ESPLORA_API_UPSTREAM must be set}"
+: "${WEB_PRICES_API_UPSTREAM:?WEB_PRICES_API_UPSTREAM must be set}"
+
 envsubst '${WEB_ESPLORA_API_UPSTREAM} ${WEB_PRICES_API_UPSTREAM}' \
   < /deployment/configs/nginx/default.conf.template \
   > /etc/nginx/conf.d/default.conf
+
+# Validate the rendered config before handing off to nginx, so a bad render
+# fails fast with a clear message rather than crash-looping the container.
+nginx -t
 
 exec "$@"


### PR DESCRIPTION
## Why

The `web` pod crash-looped in staging with:

```
nginx: [emerg] invalid URL prefix in /etc/nginx/conf.d/default.conf:15
```

Root cause: the prices proxy added to `deployment/configs/nginx/default.conf.template` uses `${WEB_PRICES_API_UPSTREAM}`, which `render-web-config.sh` substitutes via `envsubst`. The variable was not set in the deployment env, so `envsubst` produced a scheme-less `proxy_pass /prices/...;` and nginx refused to start. (The env var has since been wired into gitops.)

#87 adjusts the prices location/path but still relies on the same variable, so it does not prevent this failure mode.

## What

Harden `render-web-config.sh` so a missing upstream can't produce a cryptic crash-loop:

- Require `WEB_ESPLORA_API_UPSTREAM` and `WEB_PRICES_API_UPSTREAM` via `:?` — the container exits immediately with a message naming the missing variable.
- Run `nginx -t` on the rendered config before `exec`, failing fast with a clear error rather than letting the main process abort.

This keeps the script minimal and converts a hard-to-diagnose nginx emerg into an actionable startup error.

If you'd prefer graceful degradation over fail-fast for the (temporary, per the template TODO) prices proxy, an alternative is to skip rendering that location block when the var is unset — happy to switch to that.
