### PR TITLE
indexer: add network to configuration

### DIFF
--- a/crates/indexer/configuration/base.yaml
+++ b/crates/indexer/configuration/base.yaml
@@ -9,6 +9,7 @@ database:
 esplora:
   base_url: "https://liquid.network/liquidtestnet/api"
   timeout: 10
+  network: "liquidtestnet"
 indexer:
   protocol_fee_keeper_asset_id: "38fca2d939696061a8f76d4e6b5eecd54e3b4221c846f24a6b279e79952850a5"
   interval: 10000

--- a/crates/indexer/src/configuration.rs
+++ b/crates/indexer/src/configuration.rs
@@ -1,4 +1,4 @@
-use simplex::simplicityhl::elements::AssetId;
+use simplex::{provider::SimplicityNetwork, simplicityhl::elements::AssetId};
 
 #[derive(serde::Deserialize)]
 pub struct Settings {
@@ -36,6 +36,7 @@ impl DatabaseSettings {
 pub struct EsploraSettings {
     pub base_url: String,
     pub timeout: u16,
+    pub network: String,
 }
 
 #[derive(serde::Deserialize, Clone)]
@@ -99,9 +100,43 @@ impl TryFrom<String> for Environment {
     }
 }
 
+pub enum Network {
+    Liquid,
+    LiquidTestnet,
+    Regtest,
+}
+
+impl TryFrom<String> for Network {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match value.to_lowercase().as_str() {
+            "liquid" => Ok(Self::Liquid),
+            "liquidtestnet" => Ok(Self::LiquidTestnet),
+            "regtest" => Ok(Self::Regtest),
+            other => Err(format!(
+                "{} is not a supported network. \
+                Use `liquid`, `liquidtestnet` or `regtest`.",
+                other
+            )),
+        }
+    }
+}
+
+impl From<Network> for SimplicityNetwork {
+    fn from(value: Network) -> Self {
+        match value {
+            Network::Liquid => SimplicityNetwork::Liquid,
+            Network::LiquidTestnet => SimplicityNetwork::LiquidTestnet,
+            Network::Regtest => SimplicityNetwork::default_regtest(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{DatabaseSettings, Environment};
+    use super::{DatabaseSettings, Environment, Network};
+    use simplex::provider::SimplicityNetwork;
 
     #[test]
     fn connection_string_builds_expected_postgres_url() {
@@ -143,5 +178,41 @@ mod tests {
     fn environment_as_str_returns_expected_values() {
         assert_eq!(Environment::Local.as_str(), "local");
         assert_eq!(Environment::Production.as_str(), "production");
+    }
+
+    #[test]
+    fn network_try_from_is_case_insensitive() {
+        assert!(matches!(
+            Network::try_from("Liquid".to_string()),
+            Ok(Network::Liquid)
+        ));
+        assert!(matches!(
+            Network::try_from("LIQUIDTESTNET".to_string()),
+            Ok(Network::LiquidTestnet)
+        ));
+        assert!(matches!(
+            Network::try_from("regtest".to_string()),
+            Ok(Network::Regtest)
+        ));
+    }
+
+    #[test]
+    fn network_try_from_invalid_returns_error() {
+        let result = Network::try_from("mainnet".to_string());
+        assert!(result.is_err());
+        let err = result.err().unwrap_or_default();
+        assert!(err.contains("not a supported network"));
+    }
+
+    #[test]
+    fn network_into_simplicity_network() {
+        let liquid: SimplicityNetwork = Network::Liquid.into();
+        assert_eq!(liquid, SimplicityNetwork::Liquid);
+
+        let testnet: SimplicityNetwork = Network::LiquidTestnet.into();
+        assert_eq!(testnet, SimplicityNetwork::LiquidTestnet);
+
+        let regtest: SimplicityNetwork = Network::Regtest.into();
+        assert_eq!(regtest, SimplicityNetwork::default_regtest());
     }
 }

--- a/crates/indexer/src/esplora_client.rs
+++ b/crates/indexer/src/esplora_client.rs
@@ -6,6 +6,8 @@ use simplex::{
     simplicityhl::elements::{Transaction, Txid, encode},
 };
 
+use crate::configuration::Network;
+
 /// Default Esplora API base URL for Liquid testnet.
 pub const DEFAULT_BASE_URL: &str = "https://blockstream.info/liquidtestnet/api";
 
@@ -17,6 +19,7 @@ pub const DEFAULT_TIMEOUT_SECS: u64 = 10;
 pub struct EsploraClient {
     base_url: String,
     client: Client,
+    network: SimplicityNetwork,
 }
 
 impl Default for EsploraClient {
@@ -42,11 +45,25 @@ impl EsploraClient {
         Self {
             base_url: base_url.trim_end_matches('/').to_owned(),
             client,
+            network: SimplicityNetwork::LiquidTestnet,
         }
     }
 
+    pub fn with_network(self, network: &str) -> Result<Self, String> {
+        let simplicity_network = Network::try_from(network.to_string())?;
+        Ok(Self {
+            base_url: self.base_url,
+            client: self.client,
+            network: simplicity_network.into(),
+        })
+    }
+
     pub fn to_simplex_provider(&self) -> EsploraProvider {
-        EsploraProvider::new(self.base_url.clone(), SimplicityNetwork::LiquidTestnet)
+        EsploraProvider::new(self.base_url.clone(), self.network)
+    }
+
+    pub fn network(&self) -> SimplicityNetwork {
+        self.network
     }
 
     pub async fn get_latest_block_hash(&self) -> Result<String, EsploraClientError> {
@@ -176,5 +193,15 @@ mod tests {
         let provider = client.to_simplex_provider();
 
         assert_eq!(*provider.get_network(), SimplicityNetwork::LiquidTestnet);
+    }
+
+    #[test]
+    fn to_simplex_provider_returns_custom_network() {
+        let client = EsploraClient::with_base_url("https://example.com/api")
+            .with_network("liquid")
+            .unwrap();
+        let provider = client.to_simplex_provider();
+
+        assert_eq!(*provider.get_network(), SimplicityNetwork::Liquid);
     }
 }

--- a/crates/indexer/src/indexer/worker.rs
+++ b/crates/indexer/src/indexer/worker.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-use simplex::provider::SimplicityNetwork;
 use sqlx::PgPool;
 use tokio::time::{Interval, interval};
 
@@ -26,11 +25,10 @@ impl Worker {
             .await
             .expect("Failed to get last indexed height");
 
-        // TODO: move network to the settings
         let tracker_registry = TrackerRegistry::load(
             &db_pool,
             settings.protocol_fee_keeper_asset_id,
-            SimplicityNetwork::LiquidTestnet,
+            client.network(),
         )
         .await?;
 

--- a/crates/indexer/src/main.rs
+++ b/crates/indexer/src/main.rs
@@ -20,7 +20,9 @@ async fn main() -> Result<(), std::io::Error> {
 
     match run_mode.as_str() {
         "indexer" => {
-            let esplora_client = EsploraClient::with_base_url(&configuration.esplora.base_url);
+            let esplora_client = EsploraClient::with_base_url(&configuration.esplora.base_url)
+                .with_network(&configuration.esplora.network)
+                .expect("Invalid network configured");
 
             tracing::info!("Starting indexer service");
 

--- a/deployment/configs/backend/base.yaml.template
+++ b/deployment/configs/backend/base.yaml.template
@@ -9,6 +9,7 @@ database:
 esplora:
   base_url: "${INDEXER_ESPLORA_BASE_URL}"
   timeout: 10
+  network: "liquidtestnet"
 indexer:
   protocol_fee_keeper_asset_id: "38fca2d939696061a8f76d4e6b5eecd54e3b4221c846f24a6b279e79952850a5"
   interval: ${INDEXER_POLL_INTERVAL_MS}


### PR DESCRIPTION
Addresses the TODO in the comment.

This routes the network through ElementsSettings and ElementsClient because it's also needed network to construct the SimplexProvider with the correct network. I could move it to IndexerSettings instead if needed.