### PR TITLE
Add exclude participant filters

### DIFF
--- a/crates/indexer/README.md
+++ b/crates/indexer/README.md
@@ -223,6 +223,8 @@ The following parameters are available for `GET /offers`, `GET /borrowers/offers
 - `factory_id`: Filter by issuance factory UUID.
 - `collateral_asset`: Hex identifier of the collateral asset (same byte order as in API responses). Filters by `collateral_asset_id` when set alone.
 - `principal_asset`: Hex identifier of the principal asset (same byte order as in API responses). Filters by `principal_asset_id` when set alone. When both `collateral_asset` and `principal_asset` are set, offers must match the asset pair (collateral **and** principal).
+- `exclude_participant_script`: Hex script pubkey. Excludes offers where this script is the latest participant for the given role (e.g. hide a user's own pending offers from the lender marketplace list).
+- `exclude_participant_role`: `borrower` or `lender` (default: `borrower`). Used together with `exclude_participant_script`; ignored when the script parameter is omitted.
 - `limit`: Maximum number of records to return (default: 50, max: 100).
 - `offset`: Pagination offset (default: 0).
 - `sort_by`: `updated_at_height`, `created_at_height`, `collateral_amount`, `principal_amount`, `interest_rate`, `loan_expiration_height` (default: `updated_at_height`).

--- a/crates/indexer/src/api/offers/handlers.rs
+++ b/crates/indexer/src/api/offers/handlers.rs
@@ -45,8 +45,10 @@ pub async fn get_overview(
 #[tracing::instrument(name = "Getting offers list", skip(state, query))]
 pub async fn list_offers(
     State(state): State<Arc<AppState>>,
-    Query(query): Query<OfferListQuery>,
+    Query(mut query): Query<OfferListQuery>,
 ) -> Result<Json<OfferListResponse>, ApiError> {
+    query.prepare_exclude_participant()?;
+
     let offers = super::db::fetch_list(&state.db, query).await?;
 
     Ok(Json(offers))

--- a/crates/indexer/src/api/offers/list_query.rs
+++ b/crates/indexer/src/api/offers/list_query.rs
@@ -59,6 +59,7 @@ pub async fn fetch_participant_offers_list(
         collateral_asset = ?query.collateral_asset,
         principal_asset = ?query.principal_asset,
         factory_id = ?query.factory_id,
+        exclude_participant = query.exclude_participant_for_sql().is_some(),
         sort_by = ?query.sort_by,
         sort_dir = ?query.sort_dir,
         participant_role = ?participant.map(|(role, _)| role),

--- a/crates/indexer/src/api/openapi/params.rs
+++ b/crates/indexer/src/api/openapi/params.rs
@@ -5,6 +5,7 @@ use utoipa::IntoParams;
 use uuid::Uuid;
 
 use crate::api::params::{OfferSortBy, ScriptQuery, SortDir};
+use crate::models::ParticipantType;
 
 /// OpenAPI query parameters for `GET /offers` (flat query string).
 #[derive(IntoParams)]
@@ -18,6 +19,11 @@ pub struct OfferListParams {
     /// Principal asset hex (same byte order as API responses).
     pub principal_asset: Option<String>,
     pub factory_id: Option<Uuid>,
+    /// Excludes offers where this script is the latest participant for the given role.
+    #[param(example = "52ac")]
+    pub exclude_participant_script: Option<String>,
+    /// Participant role for `exclude_participant_script` (default: `borrower`).
+    pub exclude_participant_role: Option<ParticipantType>,
     /// Maximum records to return (default 50, max 100).
     #[param(minimum = 0, maximum = 100, example = 50)]
     pub limit: Option<u64>,

--- a/crates/indexer/src/api/params.rs
+++ b/crates/indexer/src/api/params.rs
@@ -5,7 +5,9 @@ use utoipa::{IntoParams, ToSchema};
 
 use uuid::Uuid;
 
-use crate::models::OfferStatus;
+use crate::api::error::ApiError;
+use crate::api::utils::parse_script_pubkey;
+use crate::models::{OfferStatus, ParticipantType};
 
 #[derive(Deserialize, IntoParams, ToSchema)]
 #[into_params(parameter_in = Query)]
@@ -61,6 +63,13 @@ pub struct OfferFilters {
     /// Principal asset hex (same byte order as API responses).
     pub principal_asset: Option<String>,
     pub factory_id: Option<Uuid>,
+    /// Excludes offers where this script is the latest participant for the given role.
+    pub exclude_participant_script: Option<String>,
+    /// Participant role for `exclude_participant_script` (default: `borrower`).
+    #[serde(default)]
+    pub exclude_participant_role: Option<ParticipantType>,
+    #[serde(skip, default)]
+    parsed_exclude_participant: Option<(ParticipantType, Vec<u8>)>,
     /// Maximum records to return (default 50, max 100).
     #[serde(default, deserialize_with = "deserialize_optional_u64")]
     pub limit: Option<u64>,
@@ -83,6 +92,28 @@ impl OfferFilters {
 
     pub fn effective_offset(&self) -> u64 {
         self.offset.unwrap_or(0)
+    }
+
+    /// Validates and decodes `exclude_participant_script` into an owned form for SQL filters.
+    pub fn prepare_exclude_participant(&mut self) -> Result<(), ApiError> {
+        let Some(script_hex) = self.exclude_participant_script.as_deref() else {
+            return Ok(());
+        };
+
+        let script_bytes = parse_script_pubkey(script_hex)?;
+        let participant_type = self
+            .exclude_participant_role
+            .unwrap_or(ParticipantType::Borrower);
+
+        self.parsed_exclude_participant = Some((participant_type, script_bytes));
+
+        Ok(())
+    }
+
+    pub fn exclude_participant_for_sql(&self) -> Option<(ParticipantType, &[u8])> {
+        self.parsed_exclude_participant
+            .as_ref()
+            .map(|(role, script)| (*role, script.as_slice()))
     }
 }
 
@@ -108,6 +139,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::{OfferListQuery, OfferStatus};
+    use crate::models::ParticipantType;
 
     #[test]
     fn offer_list_query_caps_limit() {
@@ -166,5 +198,60 @@ mod tests {
             parsed.sort_by,
             super::OfferSortBy::UpdatedAtHeight
         ));
+    }
+
+    #[test]
+    fn offer_list_query_parses_exclude_participant_script() {
+        let parsed: OfferListQuery =
+            serde_urlencoded::from_str("exclude_participant_script=52ac").expect("parse exclude");
+        assert_eq!(parsed.exclude_participant_script.as_deref(), Some("52ac"));
+        assert_eq!(parsed.exclude_participant_role, None);
+    }
+
+    #[test]
+    fn offer_list_query_parses_exclude_participant_role() {
+        let parsed: OfferListQuery = serde_urlencoded::from_str(
+            "exclude_participant_script=52ac&exclude_participant_role=lender",
+        )
+        .expect("parse exclude role");
+        assert_eq!(parsed.exclude_participant_script.as_deref(), Some("52ac"));
+        assert_eq!(
+            parsed.exclude_participant_role,
+            Some(ParticipantType::Lender)
+        );
+    }
+
+    #[test]
+    fn offer_list_query_prepare_exclude_participant_defaults_role_to_borrower() {
+        let mut query: OfferListQuery =
+            serde_urlencoded::from_str("exclude_participant_script=52ac").expect("parse exclude");
+        query
+            .prepare_exclude_participant()
+            .expect("prepare exclude");
+
+        let (role, script) = query.exclude_participant_for_sql().expect("parsed exclude");
+        assert_eq!(role, ParticipantType::Borrower);
+        assert_eq!(script, &[0x52, 0xac]);
+    }
+
+    #[test]
+    fn offer_list_query_prepare_exclude_participant_honors_role() {
+        let mut query: OfferListQuery = serde_urlencoded::from_str(
+            "exclude_participant_script=52ac&exclude_participant_role=lender",
+        )
+        .expect("parse exclude role");
+        query
+            .prepare_exclude_participant()
+            .expect("prepare exclude");
+
+        let (role, _) = query.exclude_participant_for_sql().expect("parsed exclude");
+        assert_eq!(role, ParticipantType::Lender);
+    }
+
+    #[test]
+    fn offer_list_query_prepare_exclude_participant_rejects_invalid_hex() {
+        let mut query: OfferListQuery =
+            serde_urlencoded::from_str("exclude_participant_script=zzzz").expect("parse exclude");
+        assert!(query.prepare_exclude_participant().is_err());
     }
 }

--- a/crates/indexer/src/api/query/mod.rs
+++ b/crates/indexer/src/api/query/mod.rs
@@ -4,4 +4,6 @@ mod participants;
 
 pub use list::{attach_offer_list_order_by, attach_paginate};
 pub use offers::{attach_offer_list_filters, attach_status_any};
-pub use participants::attach_latest_participant_offers_scope;
+pub use participants::{
+    attach_exclude_participant_script_scope, attach_latest_participant_offers_scope,
+};

--- a/crates/indexer/src/api/query/offers.rs
+++ b/crates/indexer/src/api/query/offers.rs
@@ -1,6 +1,7 @@
 use sqlx::{Postgres, QueryBuilder};
 
 use crate::api::OfferListQuery;
+use crate::api::query::attach_exclude_participant_script_scope;
 use crate::api::utils::parse_filter_hex;
 use crate::models::OfferStatus;
 
@@ -51,5 +52,9 @@ pub fn attach_offer_list_filters<'a>(
                 "Failed to decode principal_asset hex filter"
             );
         }
+    }
+
+    if let Some((participant_type, script_pubkey)) = query.exclude_participant_for_sql() {
+        attach_exclude_participant_script_scope(query_builder, participant_type, script_pubkey);
     }
 }

--- a/crates/indexer/src/api/query/participants.rs
+++ b/crates/indexer/src/api/query/participants.rs
@@ -2,12 +2,51 @@ use sqlx::{Postgres, QueryBuilder};
 
 use crate::models::ParticipantType;
 
+enum ParticipantScopeMode {
+    Include,
+    Exclude,
+}
+
 pub fn attach_latest_participant_offers_scope<'a>(
     query_builder: &mut QueryBuilder<'a, Postgres>,
     participant_type: ParticipantType,
     script_pubkey: &'a [u8],
 ) {
-    query_builder.push(" AND id IN (");
+    attach_participant_script_scope(
+        query_builder,
+        ParticipantScopeMode::Include,
+        participant_type,
+        script_pubkey,
+    );
+}
+
+pub fn attach_exclude_participant_script_scope<'a>(
+    query_builder: &mut QueryBuilder<'a, Postgres>,
+    participant_type: ParticipantType,
+    script_pubkey: &'a [u8],
+) {
+    attach_participant_script_scope(
+        query_builder,
+        ParticipantScopeMode::Exclude,
+        participant_type,
+        script_pubkey,
+    );
+}
+
+fn attach_participant_script_scope<'a>(
+    query_builder: &mut QueryBuilder<'a, Postgres>,
+    mode: ParticipantScopeMode,
+    participant_type: ParticipantType,
+    script_pubkey: &'a [u8],
+) {
+    match mode {
+        ParticipantScopeMode::Include => {
+            query_builder.push(" AND id IN (");
+        }
+        ParticipantScopeMode::Exclude => {
+            query_builder.push(" AND id NOT IN (");
+        }
+    }
     query_builder.push(
         "SELECT offer_id FROM (
             SELECT DISTINCT ON (offer_id) offer_id, script_pubkey

--- a/crates/indexer/tests/api_integration.rs
+++ b/crates/indexer/tests/api_integration.rs
@@ -368,6 +368,163 @@ async fn offers_expose_and_sort_by_updated_at_height() -> anyhow::Result<()> {
     Ok(())
 }
 
+async fn seed_pending_offer_with_participant_script(
+    pool: &PgPool,
+    factory_id: Uuid,
+    txid_seed: i64,
+    created_at_height: i64,
+    participant_type: ParticipantType,
+    script_pubkey: Vec<u8>,
+) -> anyhow::Result<i64> {
+    let mut offer = offer_model(txid_seed, factory_id, created_at_height);
+    let offer_id = seed_offer_row(pool, &mut offer).await?;
+
+    let outpoint = outpoint_from_offer_id(txid_seed, 0);
+    seed_participant_utxo_row(
+        pool,
+        &unspent_participant(
+            offer_id,
+            participant_type,
+            outpoint,
+            script_pubkey,
+            created_at_height,
+        ),
+    )
+    .await?;
+
+    Ok(offer_id)
+}
+
+#[tokio::test]
+#[serial]
+async fn offers_exclude_participant_script_filters_own_pending_offers() -> anyhow::Result<()> {
+    let pool = test_pool().await?;
+
+    let factory_id = Uuid::new_v4();
+    seed_factory_row(
+        &pool,
+        &factory_model(factory_id, 1, unique_32_bytes_from_uuid(factory_id)),
+    )
+    .await?;
+
+    let offer_a = seed_pending_offer_with_participant_script(
+        &pool,
+        factory_id,
+        10,
+        100,
+        ParticipantType::Borrower,
+        vec![0x52, 0xac],
+    )
+    .await?;
+    let offer_b = seed_pending_offer_with_participant_script(
+        &pool,
+        factory_id,
+        20,
+        200,
+        ParticipantType::Borrower,
+        vec![0x53, 0xac],
+    )
+    .await?;
+
+    let (base_url, server_handle) = start_api(pool).await?;
+    let http = reqwest::Client::new();
+
+    let all = get_json(&http, format!("{base_url}/offers?status=pending")).await?;
+    assert_eq!(all["total"], 2);
+    assert_ids_match_unordered(offer_list_items(&all), &[offer_a, offer_b]);
+
+    let exclude_a = get_json(
+        &http,
+        format!("{base_url}/offers?status=pending&exclude_participant_script=52ac"),
+    )
+    .await?;
+    assert_eq!(exclude_a["total"], 1);
+    assert_eq!(offer_list_items(&exclude_a)[0]["id"], offer_b.to_string());
+
+    let exclude_b = get_json(
+        &http,
+        format!("{base_url}/offers?status=pending&exclude_participant_script=53ac"),
+    )
+    .await?;
+    assert_eq!(exclude_b["total"], 1);
+    assert_eq!(offer_list_items(&exclude_b)[0]["id"], offer_a.to_string());
+
+    let invalid = http
+        .get(format!(
+            "{base_url}/offers?status=pending&exclude_participant_script=zzzz"
+        ))
+        .send()
+        .await?;
+    assert_eq!(invalid.status(), StatusCode::BAD_REQUEST);
+
+    server_handle.abort();
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn offers_exclude_participant_script_honors_role() -> anyhow::Result<()> {
+    let pool = test_pool().await?;
+
+    let factory_id = Uuid::new_v4();
+    seed_factory_row(
+        &pool,
+        &factory_model(factory_id, 1, unique_32_bytes_from_uuid(factory_id)),
+    )
+    .await?;
+
+    let offer_a = seed_pending_offer_with_participant_script(
+        &pool,
+        factory_id,
+        10,
+        100,
+        ParticipantType::Borrower,
+        vec![0x52, 0xac],
+    )
+    .await?;
+    let offer_b = seed_pending_offer_with_participant_script(
+        &pool,
+        factory_id,
+        20,
+        200,
+        ParticipantType::Lender,
+        vec![0x52, 0xac],
+    )
+    .await?;
+
+    let (base_url, server_handle) = start_api(pool).await?;
+    let http = reqwest::Client::new();
+
+    let exclude_borrower = get_json(
+        &http,
+        format!(
+            "{base_url}/offers?status=pending&exclude_participant_script=52ac&exclude_participant_role=borrower"
+        ),
+    )
+    .await?;
+    assert_eq!(exclude_borrower["total"], 1);
+    assert_eq!(
+        offer_list_items(&exclude_borrower)[0]["id"],
+        offer_b.to_string()
+    );
+
+    let exclude_lender = get_json(
+        &http,
+        format!(
+            "{base_url}/offers?status=pending&exclude_participant_script=52ac&exclude_participant_role=lender"
+        ),
+    )
+    .await?;
+    assert_eq!(exclude_lender["total"], 1);
+    assert_eq!(
+        offer_list_items(&exclude_lender)[0]["id"],
+        offer_a.to_string()
+    );
+
+    server_handle.abort();
+    Ok(())
+}
+
 #[tokio::test]
 #[serial]
 async fn get_offers_overview_returns_active_totals_only() -> anyhow::Result<()> {


### PR DESCRIPTION
In the current PR, exclude filters were added for the endpoint that retrieves offers