### PR TITLE
ci: identify image tags by source channel

### DIFF
--- a/gitlab/functions.yaml
+++ b/gitlab/functions.yaml
@@ -39,7 +39,13 @@ create_timestamp:
     - when: manual
   script:
     - PLATFORM=linux/${ARCH}
-    - TAG=${CI_COMMIT_SHORT_SHA}-${TIMESTAMP}
+    - |
+      if [ "${CI_COMMIT_BRANCH}" = "${CI_DEFAULT_BRANCH}" ]; then
+        IMAGE_CHANNEL="${CI_DEFAULT_BRANCH}"
+      else
+        IMAGE_CHANNEL="branch-${CI_COMMIT_REF_SLUG}"
+      fi
+      TAG="${IMAGE_CHANNEL}-${CI_COMMIT_SHORT_SHA}-${TIMESTAMP}"
     - echo "Using timestamp ${TIMESTAMP} and tag ${TAG}"
     - CONTEXT=${CONTEXT:-.}
     - BUILD_ARG_FLAGS=""


### PR DESCRIPTION
## What changed

- Prefix default-branch images with `main-`.
- Prefix manually built branch images with `branch-<ref-slug>-`.
- Preserve the existing commit SHA and timestamp ordering.

## Why

Flux currently sees every image as `<sha>-<timestamp>` and therefore cannot distinguish a `main` build from a manually triggered feature-branch build. A destructive feature-branch image was consequently selected and deployed to staging.

This change gives Flux a stable deployment channel to filter while retaining branch images for manual testing. The corresponding Kubernetes policy accepts only `main-*` tags.

## Rollout

Bootstrap backend and web tags have already been published from the current `main` commit (`358f5667`):

`main-358f5667-20260729113606`

That allows the Kubernetes ImagePolicy MR to merge before this PR. Flux will initially select the bootstrap artifacts. Once this PR merges, subsequent default-branch pipelines will publish newer `main-*` tags and normal automatic deployments will resume. Feature-branch images will use `branch-*` tags and remain invisible to the deployment policy.

## Impact

Feature-branch builds remain available for manual testing but cannot automatically roll out to Simplicity Lending staging.

## Validation

- `glab ci lint --include-jobs`
- Smoke-tested default and feature branch tag generation.
- `git diff --check`
- Verified both bootstrap tags exist in Artifact Registry and match the new Flux policy.
